### PR TITLE
support a backend parameter for jails

### DIFF
--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -13,7 +13,7 @@ define fail2ban::jail (
   $findtime                    = undef,
   $bantime                     = $fail2ban::bantime,
   $port                        = undef,
-  $backend                     = undef,
+  Optional[String] $backend    = undef,
 
 
   $config_dir_filter_path   = $fail2ban::config_dir_filter_path,
@@ -38,7 +38,6 @@ define fail2ban::jail (
   if $findtime { validate_integer($findtime) }
   if $bantime { validate_integer($bantime) }
   if $port { validate_string($port) }
-  if $backend { validate_string($action) }
 
   if $config_dir_filter_path { validate_absolute_path($config_dir_filter_path) }
   if $config_file_owner { validate_string($config_file_owner) }

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -13,6 +13,7 @@ define fail2ban::jail (
   $findtime                    = undef,
   $bantime                     = $fail2ban::bantime,
   $port                        = undef,
+  $backend                     = undef,
 
 
   $config_dir_filter_path   = $fail2ban::config_dir_filter_path,
@@ -37,6 +38,7 @@ define fail2ban::jail (
   if $findtime { validate_integer($findtime) }
   if $bantime { validate_integer($bantime) }
   if $port { validate_string($port) }
+  if $backend { validate_string($action) }
 
   if $config_dir_filter_path { validate_absolute_path($config_dir_filter_path) }
   if $config_file_owner { validate_string($config_file_owner) }

--- a/templates/common/custom_jail.conf.erb
+++ b/templates/common/custom_jail.conf.erb
@@ -18,3 +18,6 @@ bantime  = <%= @bantime %>
 <% if @port -%>
 port     = <%= @port %>
 <% end -%>
+<% if @backend -%>
+backend  = <%= @backend %>
+<% end -%>


### PR DESCRIPTION
On RedHat systems there is a nagging systemd backend issue that is causing many headaches. The only brute force way at the moment to avoid getting an automatic systemd backend is to set the default_backend, and backend in each jail, to a value other than systemd or auto.

This pull request adds a parameter, to jail.pp to support an optional backend parameter.