### PR TITLE
include compatibility with Debian Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Users can add their own jails by using this YAML definition:
 
 This module has been tested on:
 
-* Debian 6/7/8
+* Debian 6/7/8/9
 * Ubuntu 12.04/14.04/16.04
 * RedHat 5/6/7
 * CentOS 5/6/7

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,6 +9,8 @@ class fail2ban::install {
   }
 
   if $::fail2ban::package_list {
-    ensure_resource('package', $::fail2ban::package_list, { 'ensure' => $::fail2ban::package_ensure })
+    ensure_resource('package', $::fail2ban::package_list, {
+      'ensure' => $::fail2ban::package_ensure,
+    })
   }
 }

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -1,18 +1,18 @@
 # == Define: fail2ban::jail
 #
 define fail2ban::jail (
-  $filter_includes             = undef,
-  $filter_failregex            = undef,
-  $filter_ignoreregex          = undef,
-  $filter_additional_config    = undef,
-  $enabled                     = true,
-  $action                      = undef,
-  $filter                      = undef,
-  $logpath                     = undef,
-  $maxretry                    = $fail2ban::maxtretry,
-  $findtime                    = undef,
-  $bantime                     = $fail2ban::bantime,
-  $port                        = undef,
+  $filter_includes          = undef,
+  $filter_failregex         = undef,
+  $filter_ignoreregex       = undef,
+  $filter_additional_config = undef,
+  $enabled                  = true,
+  $action                   = undef,
+  $filter                   = undef,
+  $logpath                  = undef,
+  $maxretry                 = $fail2ban::maxtretry,
+  $findtime                 = undef,
+  $bantime                  = $fail2ban::bantime,
+  $port                     = undef,
 
 
   $config_dir_filter_path   = $fail2ban::config_dir_filter_path,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,10 +46,8 @@ class fail2ban::params {
   }
 
   case $::osfamily {
-    'Debian': {
-    }
-    'RedHat': {
-    }
+    'Debian': {}
+    'RedHat': {}
     default: {
       fail("${::operatingsystem} not supported.")
     }

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,8 @@
       "operatingsystemrelease": [
         "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/acceptance/nodesets/debian-9.1.0-amd64.yml
+++ b/spec/acceptance/nodesets/debian-9.1.0-amd64.yml
@@ -1,0 +1,17 @@
+# TODO:
+#   setup vagrant box for stretch
+#   change ip: to match location
+#---
+#HOSTS:
+#  debian-9.1.0-amd64:
+#    roles:
+#      - master
+#    platform: debian-9-amd64
+#    box: dhoppe/debian-9.1.0-amd64-nocm
+#    hypervisor: vagrant_virtualbox
+#    ip: 192.168.56.
+#CONFIG:
+#  type: foss
+#...
+#
+# vim: syntax=yaml

--- a/templates/stretch/etc/fail2ban/jail.conf.erb
+++ b/templates/stretch/etc/fail2ban/jail.conf.erb
@@ -1,0 +1,1007 @@
+#
+# THIS FILE IS MANAGED BY PUPPET
+# <%= file %>
+#
+
+# WARNING: heavily refactored in 0.9.0 release.  Please review and
+#          customize settings for your setup.
+#
+# Changes:  in most of the cases you should not modify this
+#           file, but provide customizations in jail.local file,
+#           or separate .conf files under jail.d/ directory, e.g.:
+#
+# HOW TO ACTIVATE JAILS:
+#
+# YOU SHOULD NOT MODIFY THIS FILE.
+#
+# It will probably be overwritten or improved in a distribution update.
+#
+# Provide customizations in a jail.local file or a jail.d/customisation.local.
+# For example to change the default bantime for all jails and to enable the
+# ssh-iptables jail the following (uncommented) would appear in the .local file.
+# See man 5 jail.conf for details.
+#
+# [DEFAULT]
+# bantime = 3600
+#
+# [sshd]
+# enabled = true
+#
+# See jail.conf(5) man page for more information
+
+
+
+# Comments: use '#' for comment lines and ';' (following a space) for inline comments
+
+
+[INCLUDES]
+
+#before = paths-distro.conf
+before = paths-debian.conf
+
+# The DEFAULT allows a global definition of the options. They can be overridden
+# in each jail afterwards.
+
+[DEFAULT]
+
+#
+# MISCELLANEOUS OPTIONS
+#
+
+# "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban will not
+# ban a host which matches an address in this list. Several addresses can be
+# defined using space (and/or comma) separator.
+ignoreip = <%= scope['::fail2ban::whitelist'].join(" ") %>
+
+# External command that will take an tagged arguments to ignore, e.g. <ip>,
+# and return true if the IP is to be ignored. False otherwise.
+#
+# ignorecommand = /path/to/command <ip>
+ignorecommand =
+
+# "bantime" is the number of seconds that a host is banned.
+bantime  = <%= scope['::fail2ban::bantime'] %>
+
+# A host is banned if it has generated "maxretry" during the last "findtime"
+# seconds.
+findtime  = 600
+
+# "maxretry" is the number of failures before a host get banned.
+maxretry = <%= scope['::fail2ban::maxretry'] %>
+
+# "backend" specifies the backend used to get files modification.
+# Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
+# This option can be overridden in each jail as well.
+#
+# pyinotify: requires pyinotify (a file alteration monitor) to be installed.
+#              If pyinotify is not installed, Fail2ban will use auto.
+# gamin:     requires Gamin (a file alteration monitor) to be installed.
+#              If Gamin is not installed, Fail2ban will use auto.
+# polling:   uses a polling algorithm which does not require external libraries.
+# systemd:   uses systemd python library to access the systemd journal.
+#              Specifying "logpath" is not valid for this backend.
+#              See "journalmatch" in the jails associated filter config
+# auto:      will try to use the following backends, in order:
+#              pyinotify, gamin, polling.
+#
+# Note: if systemd backend is chosen as the default but you enable a jail
+#       for which logs are present only in its own log files, specify some other
+#       backend for that jail (e.g. polling) and provide empty value for
+#       journalmatch. See https://github.com/fail2ban/fail2ban/issues/959#issuecomment-74901200
+backend = auto
+
+# "usedns" specifies if jails should trust hostnames in logs,
+#   warn when DNS lookups are performed, or ignore all hostnames in logs
+#
+# yes:   if a hostname is encountered, a DNS lookup will be performed.
+# warn:  if a hostname is encountered, a DNS lookup will be performed,
+#        but it will be logged as a warning.
+# no:    if a hostname is encountered, will not be used for banning,
+#        but it will be logged as info.
+# raw:   use raw value (no hostname), allow use it for no-host filters/actions (example user)
+usedns = warn
+
+# "logencoding" specifies the encoding of the log files handled by the jail
+#   This is used to decode the lines from the log file.
+#   Typical examples:  "ascii", "utf-8"
+#
+#   auto:   will use the system locale setting
+logencoding = auto
+
+# "enabled" enables the jails.
+#  By default all jails are disabled, and it should stay this way.
+#  Enable only relevant to your setup jails in your .local or jail.d/*.conf
+#
+# true:  jail will be enabled and log files will get monitored for changes
+# false: jail is not enabled
+enabled = false
+
+
+# "filter" defines the filter to use by the jail.
+#  By default jails have names matching their filter name
+#
+filter = %(__name__)s
+
+
+#
+# ACTIONS
+#
+
+# Some options used for actions
+
+# Destination email address used solely for the interpolations in
+# jail.{conf,local,d/*} configuration files.
+destemail = <%= scope['::fail2ban::email'] %>
+
+# Name of the sender for mta actions
+sendername = Fail2ban
+
+# Sender email address used solely for some actions
+sender = root@localhost
+
+# E-mail action. Since 0.8.1 Fail2Ban uses sendmail MTA for the
+# mailing. Change mta configuration parameter to mail if you want to
+# revert to conventional 'mail'.
+mta = sendmail
+
+# Default protocol
+protocol = tcp
+
+# Specify chain where jumps would need to be added in iptables-* actions
+chain = INPUT
+
+# Ports to be banned
+# Usually should be overridden in a particular jail
+port = 0:65535
+
+# Format of user-agent https://tools.ietf.org/html/rfc7231#section-5.5.3
+fail2ban_agent = Fail2Ban/%(fail2ban_version)s
+
+#
+# Action shortcuts. To be used to define action parameter
+
+# Default banning action (e.g. iptables, iptables-new,
+# iptables-multiport, shorewall, etc) It is used to define
+# action_* variables. Can be overridden globally or per
+# section within jail.local file
+banaction = iptables-multiport
+banaction_allports = iptables-allports
+
+# The simplest action to take: ban only
+action_ = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+
+# ban & send an e-mail with buffered report to the destemail.
+action_mb = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+              %(mta)s-buffered[name=%(__name__)s, dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s", sendername="%(sendername)s"]
+
+# ban & send an e-mail with whois report to the destemail.
+action_mw = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+            %(mta)s-whois[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
+
+# ban & send an e-mail with whois report and relevant log lines
+# to the destemail.
+action_mwl = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+             %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+
+# See the IMPORTANT note in action.d/xarf-login-attack for when to use this action
+#
+# ban & send a xarf e-mail to abuse contact of IP address and include relevant log lines
+# to the destemail.
+action_xarf = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+             xarf-login-attack[service=%(__name__)s, sender="%(sender)s", logpath=%(logpath)s, port="%(port)s"]
+
+# ban IP on CloudFlare & send an e-mail with whois report and relevant log lines
+# to the destemail.
+action_cf_mwl = cloudflare[cfuser="%(cfemail)s", cftoken="%(cfapikey)s"]
+                %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+
+# Report block via blocklist.de fail2ban reporting service API
+#
+# See the IMPORTANT note in action.d/blocklist_de.conf for when to
+# use this action. Create a file jail.d/blocklist_de.local containing
+# [Init]
+# blocklist_de_apikey = {api key from registration]
+#
+action_blocklist_de  = blocklist_de[email="%(sender)s", service=%(filter)s, apikey="%(blocklist_de_apikey)s", agent="%(fail2ban_agent)s"]
+
+# Report ban via badips.com, and use as blacklist
+#
+# See BadIPsAction docstring in config/action.d/badips.py for
+# documentation for this action.
+#
+# NOTE: This action relies on banaction being present on start and therefore
+# should be last action defined for a jail.
+#
+action_badips = badips.py[category="%(__name__)s", banaction="%(banaction)s", agent="%(fail2ban_agent)s"]
+#
+# Report ban via badips.com (uses action.d/badips.conf for reporting only)
+#
+action_badips_report = badips[category="%(__name__)s", agent="%(fail2ban_agent)s"]
+
+# Choose default action.  To change, just override value of 'action' with the
+# interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
+# globally (section [DEFAULT]) or per specific section
+action = %(<%= scope['::fail2ban::action'] %>)s
+
+
+#
+# JAILS
+#
+
+#
+# SSH servers
+#
+
+[sshd]
+
+enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
+port    = ssh
+logpath = %(sshd_log)s
+backend = %(sshd_backend)s
+
+
+[sshd-ddos]
+# This jail corresponds to the standard configuration in Fail2ban.
+# The mail-whois action send a notification e-mail with a whois request
+# in the body.
+port    = ssh
+logpath = %(sshd_log)s
+backend = %(sshd_backend)s
+
+
+[dropbear]
+
+enabled = <%= scope['::fail2ban::jails'].include? "dropbear" %>
+port    = ssh
+logpath = %(dropbear_log)s
+backend = %(dropbear_backend)s
+
+
+[selinux-ssh]
+
+enabled = <%= scope['::fail2ban::jails'].include? "selinux-ssh" %>
+port    = ssh
+logpath = %(auditd_log)s
+
+
+#
+# HTTP servers
+#
+[apache]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache" %>
+port     = http,https
+filter   = apache-auth
+logpath  = %(apache_error_log)s
+maxretry = 6
+
+[apache-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "apache-auth" %>
+port    = http,https
+logpath = %(apache_error_log)s
+
+
+[apache-badbots]
+# Ban hosts which agent identifies spammer robots crawling the web
+# for email addresses. The mail outputs are buffered.
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-badbots" %>
+port     = http,https
+logpath  = %(apache_access_log)s
+bantime  = 172800
+maxretry = 1
+
+
+[apache-noscript]
+
+enabled = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
+port    = http,https
+logpath = %(apache_error_log)s
+
+
+[apache-overflows]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+
+[apache-nohome]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+
+[apache-botsearch]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-botsearch" %>
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+
+[apache-fakegooglebot]
+
+enabled       = <%= scope['::fail2ban::jails'].include? "apache-fakegooglebot" %>
+port          = http,https
+logpath       = %(apache_access_log)s
+maxretry      = 1
+ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
+
+
+[apache-modsecurity]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+
+[apache-shellshock]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-shellshock" %>
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 1
+
+
+[openhab-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "openhab-auth" %>
+filter  = openhab
+action  = iptables-allports[name=NoAuthFailures]
+logpath = /opt/openhab/logs/request.log
+
+
+[nginx-http-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
+port    = http,https
+logpath = %(nginx_error_log)s
+
+# To use 'nginx-limit-req' jail you should have `ngx_http_limit_req_module`
+# and define `limit_req` and `limit_req_zone` as described in nginx documentation
+# http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+# or for example see in 'config/filter.d/nginx-limit-req.conf'
+[nginx-limit-req]
+
+enabled = <%= scope['::fail2ban::jails'].include? "nginx-limit-reg" %>
+port    = http,https
+logpath = %(nginx_error_log)s
+
+[nginx-botsearch]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "nginx-botsearch" %>
+port     = http,https
+logpath  = %(nginx_error_log)s
+maxretry = 2
+
+# Ban attackers that try to use PHP's URL-fopen() functionality
+# through GET/POST variables. - Experimental, with more than a year
+# of usage in production environments.
+
+[php-url-fopen]
+
+enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
+port    = http,https
+logpath = %(nginx_access_log)s
+          %(apache_access_log)s
+
+[suhosin]
+
+enabled = <%= scope['::fail2ban::jails'].include? "suhosin" %>
+port    = http,https
+logpath = %(suhosin_log)s
+
+
+[lighttpd-auth]
+# Same as above for Apache's mod_auth
+# It catches wrong authentifications
+enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
+port    = http,https
+logpath = %(lighttpd_error_log)s
+
+#
+# Webmail and groupware servers
+#
+
+[roundcube-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
+port    = http,https
+logpath = %(roundcube_errors_log)s
+
+
+[openwebmail]
+
+enabled = <%= scope['::fail2ban::jails'].include? "openwebmail" %>
+port    = http,https
+logpath = /var/log/openwebmail.log
+
+
+[horde]
+
+enabled = <%= scope['::fail2ban::jails'].include? "horde" %>
+port    = http,https
+logpath = /var/log/horde/horde.log
+
+
+[groupoffice]
+
+enabled = <%= scope['::fail2ban::jails'].include? "groupoffice" %>
+port    = http,https
+logpath = /home/groupoffice/log/info.log
+
+
+[sogo-auth]
+# Monitor SOGo groupware server
+# without proxy this would be:
+# port    = 20000
+enabled = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
+port    = http,https
+logpath = /var/log/sogo/sogo.log
+
+
+[tine20]
+
+enabled = <%= scope['::fail2ban::jails'].include? "tine20" %>
+logpath = /var/log/tine20/tine20.log
+port    = http,https
+
+
+#
+# Web Applications
+#
+#
+
+[drupal-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "drupal-auth" %>
+port    = http,https
+logpath = %(syslog_daemon)s
+backend = %(syslog_backend)s
+
+[guacamole]
+
+enabled = <%= scope['::fail2ban::jails'].include? "guacamole" %>
+port    = http,https
+logpath = /var/log/tomcat*/catalina.out
+
+[monit]
+#Ban clients brute-forcing the monit gui login
+enabled = <%= scope['::fail2ban::jails'].include? "monit" %>
+port    = 2812
+logpath = /var/log/monit
+
+
+[webmin-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "webmin-auth" %>
+port    = 10000
+logpath = %(syslog_authpriv)s
+backend = %(syslog_backend)s
+
+
+[froxlor-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "froxlor-auth" %>
+port    = http,https
+logpath = %(syslog_authpriv)s
+backend = %(syslog_backend)s
+
+
+#
+# HTTP Proxy servers
+#
+#
+
+[squid]
+
+enabled = <%= scope['::fail2ban::jails'].include? "squid" %>
+port    =  80,443,3128,8080
+logpath = /var/log/squid/access.log
+
+
+[3proxy]
+
+enabled = <%= scope['::fail2ban::jails'].include? "3proxy" %>
+port    = 3128
+logpath = /var/log/3proxy.log
+
+
+#
+# FTP servers
+#
+
+
+[proftpd]
+
+enabled = <%= scope['::fail2ban::jails'].include? "proftpd" %>
+port    = ftp,ftp-data,ftps,ftps-data
+logpath = %(proftpd_log)s
+backend = %(proftpd_backend)s
+
+
+[pure-ftpd]
+
+enabled = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
+port    = ftp,ftp-data,ftps,ftps-data
+logpath = %(pureftpd_log)s
+backend = %(pureftpd_backend)s
+
+
+[gssftpd]
+
+enabled = <%= scope['::fail2ban::jails'].include? "gssftpd" %>
+port    = ftp,ftp-data,ftps,ftps-data
+logpath = %(syslog_daemon)s
+backend = %(syslog_backend)s
+
+
+[wuftpd]
+
+enabled = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
+port    = ftp,ftp-data,ftps,ftps-data
+logpath = %(wuftpd_log)s
+backend = %(wuftpd_backend)s
+
+
+[vsftpd]
+# or overwrite it in jails.local to be
+# logpath = %(syslog_authpriv)s
+# if you want to rely on PAM failed login attempts
+# vsftpd's failregex should match both of those formats
+enabled = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
+port    = ftp,ftp-data,ftps,ftps-data
+logpath = %(vsftpd_log)s
+
+
+#
+# Mail servers
+#
+
+# ASSP SMTP Proxy Jail
+[assp]
+
+enabled = <%= scope['::fail2ban::jails'].include? "assp" %>
+port    = smtp,465,submission
+logpath = /root/path/to/assp/logs/maillog.txt
+
+
+[courier-smtp]
+
+enabled = <%= scope['::fail2ban::jails'].include? "courier-smtp" %>
+port    = smtp,465,submission
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
+[postfix]
+
+enabled = <%= scope['::fail2ban::jails'].include? "postfix" %>
+port    = smtp,465,submission
+logpath = %(postfix_log)s
+backend = %(postfix_backend)s
+
+
+[postfix-rbl]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "postfix-rbl" %>
+port     = smtp,465,submission
+logpath  = %(postfix_log)s
+backend  = %(postfix_backend)s
+maxretry = 1
+
+
+[sendmail-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "sendmail-auth" %>
+port    = submission,465,smtp
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
+[sendmail-reject]
+
+enabled = <%= scope['::fail2ban::jails'].include? "sendmail-reject" %>
+port    = smtp,465,submission
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
+[qmail-rbl]
+
+enabled = <%= scope['::fail2ban::jails'].include? "qmail-rbl" %>
+filter  = qmail
+port    = smtp,465,submission
+logpath = /service/qmail/log/main/current
+
+
+# dovecot defaults to logging to the mail syslog facility
+# but can be set by syslog_facility in the dovecot configuration.
+[dovecot]
+
+enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
+port    = pop3,pop3s,imap,imaps,submission,465,sieve
+logpath = %(dovecot_log)s
+backend = %(dovecot_backend)s
+
+
+[sieve]
+
+enabled = <%= scope['::fail2ban::jails'].include? "sieve" %>
+port    = smtp,465,submission
+logpath = %(dovecot_log)s
+backend = %(dovecot_backend)s
+
+
+[solid-pop3d]
+
+enabled = <%= scope['::fail2ban::jails'].include? "solid-pop3d" %>
+port    = pop3,pop3s
+logpath = %(solidpop3d_log)s
+
+
+[exim]
+
+enabled = <%= scope['::fail2ban::jails'].include? "exim" %>
+port    = smtp,465,submission
+logpath = %(exim_main_log)s
+
+
+[exim-spam]
+
+enabled = <%= scope['::fail2ban::jails'].include? "exim-spam" %>
+port    = smtp,465,submission
+logpath = %(exim_main_log)s
+
+
+[kerio]
+
+enabled = <%= scope['::fail2ban::jails'].include? "kerio" %>
+port    = imap,smtp,imaps,465
+logpath = /opt/kerio/mailserver/store/logs/security.log
+
+
+#
+# Mail servers authenticators: might be used for smtp,ftp,imap servers, so
+# all relevant ports get banned
+#
+
+[courier-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "courier-auth" %>
+port    = smtp,465,submission,imap3,imaps,pop3,pop3s
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
+[postfix-sasl]
+
+enabled = <%= scope['::fail2ban::jails'].include? "postfix-sasl" %>
+port    = smtp,465,submission,imap3,imaps,pop3,pop3s
+# You might consider monitoring /var/log/mail.warn instead if you are
+# running postfix since it would provide the same log lines at the
+# "warn" level but overall at the smaller filesize.
+logpath = %(postfix_log)s
+backend = %(postfix_backend)s
+
+
+[perdition]
+
+enabled = <%= scope['::fail2ban::jails'].include? "perdition" %>
+port    = imap3,imaps,pop3,pop3s
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
+[squirrelmail]
+
+enabled = <%= scope['::fail2ban::jails'].include? "squirrelmail" %>
+port    = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
+
+
+[cyrus-imap]
+
+enabled = <%= scope['::fail2ban::jails'].include? "cyrus-imap" %>
+port    = imap3,imaps
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
+[uwimap-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "uwimap-auth" %>
+port    = imap3,imaps
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
+#
+#
+# DNS servers
+#
+
+
+# !!! WARNING !!!
+#   Since UDP is connection-less protocol, spoofing of IP and imitation
+#   of illegal actions is way too simple.  Thus enabling of this filter
+#   might provide an easy way for implementing a DoS against a chosen
+#   victim. See
+#    http://nion.modprobe.de/blog/archives/690-fail2ban-+-dns-fail.html
+#   Please DO NOT USE this jail unless you know what you are doing.
+#
+# IMPORTANT: see filter.d/named-refused for instructions to enable logging
+# This jail blocks UDP traffic for DNS requests.
+# [named-refused-udp]
+#
+# filter   = named-refused
+# port     = domain,953
+# protocol = udp
+# logpath  = /var/log/named/security.log
+
+# IMPORTANT: see filter.d/named-refused for instructions to enable logging
+# This jail blocks TCP traffic for DNS requests.
+
+[named-refused]
+
+enabled = <%= scope['::fail2ban::jails'].include? "named-refused" %>
+port    = domain,953
+logpath = /var/log/named/security.log
+
+
+[nsd]
+
+enabled = <%= scope['::fail2ban::jails'].include? "nsd" %>
+port    = 53
+action  = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+          %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+logpath = /var/log/nsd.log
+
+
+#
+# Miscellaneous
+#
+
+[asterisk]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "asterisk" %>
+port     = 5060,5061
+action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+logpath  = /var/log/asterisk/messages
+maxretry = 10
+
+
+[freeswitch]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
+port     = 5060,5061
+action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+logpath  = /var/log/freeswitch.log
+maxretry = 10
+
+
+# To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld] or
+# equivalent section:
+# log-warning = 2
+#
+# for syslog (daemon facility)
+# [mysqld_safe]
+# syslog
+#
+# for own logfile
+# [mysqld]
+# log-error=/var/log/mysqld.log
+[mysqld-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
+port    = 3306
+logpath = %(mysql_log)s
+backend = %(mysql_backend)s
+
+
+# Log wrong MongoDB auth (for details see filter 'filter.d/mongodb-auth.conf')
+[mongodb-auth]
+# change port when running with "--shardsvr" or "--configsvr" runtime operation
+enabled = <%= scope['::fail2ban::jails'].include? "mongodb-auth" %>
+port    = 27017
+logpath = /var/log/mongodb/mongodb.log
+
+
+# Jail for more extended banning of persistent abusers
+# !!! WARNINGS !!!
+# 1. Make sure that your loglevel specified in fail2ban.conf/.local
+#    is not at DEBUG level -- which might then cause fail2ban to fall into
+#    an infinite loop constantly feeding itself with non-informative lines
+# 2. Increase dbpurgeage defined in fail2ban.conf to e.g. 648000 (7.5 days)
+#    to maintain entries for failed logins for sufficient amount of time
+[recidive]
+
+enabled   = <%= scope['::fail2ban::jails'].include? "recidive" %>
+logpath   = /var/log/fail2ban.log
+banaction = %(banaction_allports)s
+bantime   = 604800  ; 1 week
+findtime  = 86400   ; 1 day
+
+
+# Generic filter for PAM. Has to be used with action which bans all
+# ports such as iptables-allports, shorewall
+
+[pam-generic]
+# pam-generic filter can be customized to monitor specific subset of 'tty's
+enabled   = <%= scope['::fail2ban::jails'].include? "pam-generic" %>
+banaction = %(banaction_allports)s
+logpath   = %(syslog_authpriv)s
+backend   = %(syslog_backend)s
+
+
+[xinetd-fail]
+
+enabled   = <%= scope['::fail2ban::jails'].include? "xinetd-fail" %>
+banaction = iptables-multiport-log
+logpath   = %(syslog_daemon)s
+backend   = %(syslog_backend)s
+maxretry  = 2
+
+
+# stunnel - need to set port for this
+[stunnel]
+
+enabled = <%= scope['::fail2ban::jails'].include? "stunnel" %>
+logpath = /var/log/stunnel4/stunnel.log
+
+
+[ejabberd-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "ejabberd-auth" %>
+port    = 5222
+logpath = /var/log/ejabberd/ejabberd.log
+
+
+[counter-strike]
+
+enabled = <%= scope['::fail2ban::jails'].include? "counter-strike" %>
+logpath = /opt/cstrike/logs/L[0-9]*.log
+# Firewall: http://www.cstrike-planet.com/faq/6
+tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
+udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
+action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+
+# consider low maxretry and a long bantime
+# nobody except your own Nagios server should ever probe nrpe
+[nagios]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "nagios" %>
+logpath  = %(syslog_daemon)s     ; nrpe.cfg may define a different log_facility
+backend  = %(syslog_backend)s
+maxretry = 1
+
+
+[oracleims]
+# see "oracleims" filter file for configuration requirement for Oracle IMS v6 and above
+enabled   = <%= scope['::fail2ban::jails'].include? "oracleims" %>
+logpath   = /opt/sun/comms/messaging64/log/mail.log_current
+banaction = %(banaction_allports)s
+
+[directadmin]
+
+enabled = <%= scope['::fail2ban::jails'].include? "directadmin" %>
+logpath = /var/log/directadmin/login.log
+port    = 2222
+
+[portsentry]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "portsentry" %>
+logpath  = /var/lib/portsentry/portsentry.history
+maxretry = 1
+
+[pass2allow-ftp]
+# this pass2allow example allows FTP traffic after successful HTTP authentication
+enabled      = <%= scope['::fail2ban::jails'].include? "pass2allow-ftp" %>
+port         = ftp,ftp-data,ftps,ftps-data
+# knocking_url variable must be overridden to some secret value in jail.local
+knocking_url = /knocking/
+filter       = apache-pass[knocking_url="%(knocking_url)s"]
+# access log of the website with HTTP auth
+logpath      = %(apache_access_log)s
+blocktype    = RETURN
+returntype   = DROP
+bantime      = 3600
+maxretry     = 1
+findtime     = 1
+
+
+[murmur]
+# AKA mumble-server
+enabled = <%= scope['::fail2ban::jails'].include? "murmur" %>
+port    = 64738
+action  = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol=tcp, chain="%(chain)s", actname=%(banaction)s-tcp]
+          %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol=udp, chain="%(chain)s", actname=%(banaction)s-udp]
+logpath = /var/log/mumble-server/mumble-server.log
+
+
+[screensharingd]
+# For Mac OS Screen Sharing Service (VNC)
+enabled     = <%= scope['::fail2ban::jails'].include? "screensharingd" %>
+logpath     = /var/log/system.log
+logencoding = utf-8
+
+[haproxy-http-auth]
+# HAProxy by default doesn't log to file you'll need to set it up to forward
+# logs to a syslog server which would then write them to disk.
+# See "haproxy-http-auth" filter for a brief cautionary note when setting
+# maxretry and findtime.
+enabled = <%= scope['::fail2ban::jails'].include? "haproxy-http-auth" %>
+logpath = /var/log/haproxy.log
+
+[slapd]
+
+enabled = <%= scope['::fail2ban::jails'].include? "slapd" %>
+port    = ldap,ldaps
+filter  = slapd
+logpath = /var/log/slapd.log
+
+<% if @additional_jails -%>
+#
+# Additional jails
+#
+
+[nginx-wp-login]
+
+enabled  = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-wp-login" %>
+port     = http,https
+filter   = nginx-wp-login
+logpath  = /var/log/nginx/access.log
+maxretry = 3
+findtime = 120
+bantime  = 1200
+
+# nginx login failures
+[nginx-login]
+
+enabled  = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-login" %>
+filter   = nginx-login
+action   = iptables-multiport[name=NoLoginFailures, port="http,https"]
+logpath  = /var/log/nginx*/*access*.log
+bantime  = 600 # 10 minutes
+maxretry = 6
+
+# nginx badbots
+[nginx-badbots]
+
+enabled  = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-badbots" %>
+filter   = apache-badbots
+action   = iptables-multiport[name=BadBots, port="http,https"]
+logpath  = /var/log/nginx*/*access*.log
+bantime  = 86400 # 1 day
+maxretry = 1
+
+# IPs trying to execute scripts
+[nginx-noscript]
+
+enabled  = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-noscript" %>
+action   = iptables-multiport[name=NoScript, port="http,https"]
+filter   = nginx-noscript
+logpath  = /var/log/nginx*/*access*.log
+maxretry = 6
+bantime  = 86400 # 1 day
+
+# IPs trying to use server as proxy.
+[nginx-proxy]
+
+enabled  = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-proxy" %>
+action   = iptables-multiport[name=NoProxy, port="http,https"]
+filter   = nginx-proxy
+logpath  = /var/log/nginx*/*access*.log
+maxretry = 0
+bantime  = 86400 # 1 day
+<% end -%>


### PR DESCRIPTION
README.md
  included tested on Debian 9

manifests/install.pp
  code style, no impact

manifests/jail.pp
  indentation, no impact

manifests/params.pp
  code style, no impact

metadata.json
  included operatingsystemrelease for Debian 9

spec/acceptance/nodesets/debian-9.1.0-amd64.yml
  place holder for vagrant

templates/stretch/etc/fail2ban/jail.conf.erb
  jail.conf file based off fail2ban (0.9.6-2), with some addional options
  included that where also defined within jessie/jail.conf

  [action_mb] defined for compatibility
  [apache to] to match README.md and assuming highly used config
  if statement for @additional_jails, copied from jessie/fail.conf
  indentation and whitespaces corrections from original fail.conf