### PR TITLE
Don't use the template source file name in the templates

### DIFF
--- a/templates/Carbon/etc/fail2ban/jail.conf.erb
+++ b/templates/Carbon/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 # Fail2Ban configuration file.

--- a/templates/Core/etc/fail2ban/jail.conf.erb
+++ b/templates/Core/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 # Fail2Ban configuration file.

--- a/templates/Final/etc/fail2ban/jail.conf.erb
+++ b/templates/Final/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 # Fail2Ban configuration file.

--- a/templates/Maipo/etc/fail2ban/jail.conf.erb
+++ b/templates/Maipo/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 # WARNING: heavily refactored in 0.9.0 release.  Please review and
 #          customize settings for your setup.

--- a/templates/Santiago/etc/fail2ban/jail.conf.erb
+++ b/templates/Santiago/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 # WARNING: heavily refactored in 0.9.0 release.  Please review and
 #          customize settings for your setup.

--- a/templates/Tikanga/etc/fail2ban/jail.conf.erb
+++ b/templates/Tikanga/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 # Fail2Ban configuration file.

--- a/templates/jessie/etc/fail2ban/jail.conf.erb
+++ b/templates/jessie/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 # Fail2Ban configuration file.

--- a/templates/precise/etc/fail2ban/jail.conf.erb
+++ b/templates/precise/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 # Fail2Ban configuration file.

--- a/templates/squeeze/etc/fail2ban/jail.conf.erb
+++ b/templates/squeeze/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 # Fail2Ban configuration file.

--- a/templates/trusty/etc/fail2ban/jail.conf.erb
+++ b/templates/trusty/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 # Fail2Ban configuration file.

--- a/templates/wheezy/etc/fail2ban/jail.conf.erb
+++ b/templates/wheezy/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 # Fail2Ban configuration file.

--- a/templates/xenial/etc/fail2ban/jail.conf.erb
+++ b/templates/xenial/etc/fail2ban/jail.conf.erb
@@ -1,6 +1,5 @@
 #
 # THIS FILE IS MANAGED BY PUPPET
-# <%= file %>
 #
 
 #


### PR DESCRIPTION
Using the full path to the template in the files changes the file
every time puppet runs against a different environment, remove
<%= file %> everywhere

Fixes #29