### PR TITLE
Add configuration option for iptables_chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ suspicious logins. Defaults to "fail2ban@${::domain}".
 Determines which email address should notify about restricted hosts and
 suspicious logins. Defaults to 'fail2ban@${::fqdn}'.
 
+#### `iptables_chain`
+
+Determines chain where jumps will to be added in iptables-\* actions. Defaults to 'INPUT'.
+
 #### `jails`
 
 Determines which services should be protected by Fail2ban. Defaults to '['ssh', 'ssh-ddos']'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class fail2ban (
   Integer[0] $bantime = 432000,
   String $email = "fail2ban@${::domain}",
   String $sender = "fail2ban@${::fqdn}",
+  String $iptables_chain = 'INPUT',
   Array[String] $jails = ['ssh', 'ssh-ddos'],
   Integer[0] $maxretry = 3,
   Array $whitelist = ['127.0.0.1/8', '192.168.56.0/24'],

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -145,6 +145,26 @@ describe 'fail2ban' do
       describe file(config_file_path) do
         it { is_expected.to be_file }
         it { is_expected.to contain 'THIS FILE IS MANAGED BY PUPPET' }
+        it { is_expected.to contain %r{^chain = INPUT$} }
+      end
+    end
+
+    context 'when content template and custom chain' do
+      it 'is_expected.to work with no errors' do
+        pp = <<-EOS
+          class { 'fail2ban':
+            config_file_template => "fail2ban/#{fact('lsbdistcodename')}/#{config_file_path}.erb",
+	    iptables_chain => 'TEST',
+          }
+        EOS
+
+        apply_manifest(pp, catch_failures: true)
+      end
+
+      describe file(config_file_path) do
+        it { is_expected.to be_file }
+        it { is_expected.to contain 'THIS FILE IS MANAGED BY PUPPET' }
+        it { is_expected.to contain %r{^chain = TEST$} }
       end
     end
   end

--- a/spec/defines/define_spec.rb
+++ b/spec/defines/define_spec.rb
@@ -57,7 +57,7 @@ describe 'fail2ban::define', type: :define do
             'content' => %r{THIS FILE IS MANAGED BY PUPPET},
             'notify'  => 'Service[fail2ban]',
             'require' => 'Package[fail2ban]'
-          )
+          ).with_content(%r{^chain = INPUT$})
         end
       end
 
@@ -77,7 +77,7 @@ describe 'fail2ban::define', type: :define do
             'content' => %r{THIS FILE IS MANAGED BY PUPPET},
             'notify'  => 'Service[fail2ban]',
             'require' => 'Package[fail2ban]'
-          )
+          ).with_content(%r{^chain = INPUT$})
         end
       end
     end

--- a/templates/Carbon/etc/fail2ban/jail.conf.erb
+++ b/templates/Carbon/etc/fail2ban/jail.conf.erb
@@ -120,7 +120,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter

--- a/templates/Core/etc/fail2ban/jail.conf.erb
+++ b/templates/Core/etc/fail2ban/jail.conf.erb
@@ -120,7 +120,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter

--- a/templates/Final/etc/fail2ban/jail.conf.erb
+++ b/templates/Final/etc/fail2ban/jail.conf.erb
@@ -120,7 +120,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter

--- a/templates/Maipo/etc/fail2ban/jail.conf.erb
+++ b/templates/Maipo/etc/fail2ban/jail.conf.erb
@@ -143,7 +143,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 # Ports to be banned
 # Usually should be overridden in a particular jail

--- a/templates/Santiago/etc/fail2ban/jail.conf.erb
+++ b/templates/Santiago/etc/fail2ban/jail.conf.erb
@@ -143,7 +143,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 # Ports to be banned
 # Usually should be overridden in a particular jail

--- a/templates/Tikanga/etc/fail2ban/jail.conf.erb
+++ b/templates/Tikanga/etc/fail2ban/jail.conf.erb
@@ -93,7 +93,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter

--- a/templates/jessie/etc/fail2ban/jail.conf.erb
+++ b/templates/jessie/etc/fail2ban/jail.conf.erb
@@ -93,7 +93,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter

--- a/templates/precise/etc/fail2ban/jail.conf.erb
+++ b/templates/precise/etc/fail2ban/jail.conf.erb
@@ -57,7 +57,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter

--- a/templates/stretch/etc/fail2ban/jail.conf.erb
+++ b/templates/stretch/etc/fail2ban/jail.conf.erb
@@ -93,7 +93,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter

--- a/templates/trusty/etc/fail2ban/jail.conf.erb
+++ b/templates/trusty/etc/fail2ban/jail.conf.erb
@@ -85,7 +85,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter

--- a/templates/wheezy/etc/fail2ban/jail.conf.erb
+++ b/templates/wheezy/etc/fail2ban/jail.conf.erb
@@ -57,7 +57,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 #
 # Action shortcuts. To be used to define action parameter

--- a/templates/xenial/etc/fail2ban/jail.conf.erb
+++ b/templates/xenial/etc/fail2ban/jail.conf.erb
@@ -145,7 +145,7 @@ mta = sendmail
 protocol = tcp
 
 # Specify chain where jumps would need to be added in iptables-* actions
-chain = INPUT
+chain = <%= scope['::fail2ban::iptables_chain'] %>
 
 # Ports to be banned
 # Usually should be overridden in a particular jail


### PR DESCRIPTION
`iptables` is already pretty fiddly on its own. Allowing a user to select a custom chain for Fail2Ban to manage (instead of INPUT) will make this management quite a bit less headache-inducing.

This change doesn't manage the chain, just instructs Fail2Ban to use it, via the config file.