### PR TITLE
Adapted validate_* to validate_legacy. Compatible to puppet 5

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,32 +37,51 @@ class fail2ban (
   $whitelist                = ['127.0.0.1/8', '192.168.56.0/24'],
   $custom_jails             = undef,
 ) inherits ::fail2ban::params {
-  validate_re($package_ensure, '^(absent|latest|present|purged)$')
-  validate_string($package_name)
+#  validate_re($package_ensure, '^(absent|latest|present|purged)$')
+  validate_legacy('Optional[String]', 'validate_re', $package_ensure, '^(absent|latest|present|purged)$')
+#  validate_string($package_name)
+  validate_legacy(String, 'validate_string', $package_name)
   if $package_list { validate_array($package_list) }
 
-  validate_absolute_path($config_dir_path)
-  validate_bool($config_dir_purge)
-  validate_bool($config_dir_recurse)
-  if $config_dir_source { validate_string($config_dir_source) }
+#  validate_absolute_path($config_dir_path)
+  validate_legacy(Stdlib::Compat::Absolute_path, 'validate_absolute_path', $config_dir_path)
+#  validate_bool($config_dir_purge)
+  validate_legacy(Boolean, 'validate_bool', $config_dir_purge)
+#  validate_bool($config_dir_recurse)
+  validate_legacy(Boolean, 'validate_bool', $config_dir_recurse)
 
-  validate_absolute_path($config_file_path)
-  validate_string($config_file_owner)
-  validate_string($config_file_group)
-  validate_string($config_file_mode)
-  if $config_file_source { validate_string($config_file_source) }
-  if $config_file_string { validate_string($config_file_string) }
-  if $config_file_template { validate_string($config_file_template) }
+  if $config_dir_source { #validate_string($config_dir_source)
+    validate_legacy( String, 'validate_string', $config_dir_source)
+  }
 
-  validate_string($config_file_notify)
-  validate_string($config_file_require)
+#  validate_absolute_path($config_file_path)
+  validate_legacy(Stdlib::Compat::Absolute_path, 'validate_absolute_path', $config_file_path)
+#  validate_string($config_file_owner)
+  validate_legacy(String, 'validate_string', $config_file_owner)
+#  validate_string($config_file_group)
+    validate_legacy(String, 'validate_string', $config_file_group)
+#  validate_string($config_file_mode)
+    validate_legacy(String, 'validate_string', $config_file_mode)
+  if $config_file_source { validate_legacy(String, 'validate_string', $config_file_mode) }  #validate_string($config_file_source) }
+  if $config_file_string { validate_legacy(String, 'validate_string', $config_file_string) } #validate_string($config_file_string) }
+  if $config_file_template { validate_legacy(String, 'validate_string', $config_file_template) }  #validate_string($config_file_template) }
 
-  validate_hash($config_file_hash)
-  validate_hash($config_file_options_hash)
+#  validate_string($config_file_notify)
+  validate_legacy(String, 'validate_string', $config_file_notify)	 
+#  validate_string($config_file_require)
+   validate_legacy(String, 'validate_string', $config_file_require) 
 
-  validate_re($service_ensure, '^(running|stopped)$')
-  validate_string($service_name)
-  validate_bool($service_enable)
+#  validate_hash($config_file_hash)
+  validate_legacy(Hash, 'validate_hash', $config_file_hash)
+#  validate_hash($config_file_options_hash)
+  validate_legacy(Hash, 'validate_hash', $config_file_options_hash)
+
+#  validate_re($service_ensure, '^(running|stopped)$')
+  validate_legacy('Optional[String]', 'validate_re', $service_ensure, '^(running|stopped)$')
+#  validate_string($service_name)
+  validate_legacy(String, 'validate_string', $service_name)
+#  validate_bool($service_enable)
+  validate_legacy(Boolean, 'validate_bool', $service_enable)
 
   $config_file_content = default_content($config_file_string, $config_file_template)
 
@@ -87,8 +106,11 @@ class fail2ban (
     $_service_enable    = $service_enable
   }
 
-  validate_re($config_dir_ensure, '^(absent|directory)$')
-  validate_re($config_file_ensure, '^(absent|present)$')
+#  validate_re($config_dir_ensure, '^(absent|directory)$')
+  validate_legacy('Optional[String]', 'validate_re', $config_dir_ensure, '^(absent|directory)$')
+#  validate_re($config_file_ensure, '^(absent|present)$')
+  validate_legacy('Optional[String]', 'validate_re', $config_file_ensure, '^(absent|directory)$')
+
 
   anchor { 'fail2ban::begin': } ->
   class { '::fail2ban::install': } ->


### PR DESCRIPTION
This can help fixing deprecated language.
#28 