### PR TITLE
Make 'ssh' and 'ssh-ddos' jail names be consistent across operating systems

### DIFF
--- a/templates/Carbon/etc/fail2ban/jail.conf.erb
+++ b/templates/Carbon/etc/fail2ban/jail.conf.erb
@@ -186,7 +186,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 #
 
 [sshd]
-enabled = <%= scope['::fail2ban::jails'].include? "sshd" %>
+enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
 port    = ssh
 logpath = %(sshd_log)s
 
@@ -195,7 +195,7 @@ logpath = %(sshd_log)s
 # This jail corresponds to the standard configuration in Fail2ban.
 # The mail-whois action send a notification e-mail with a whois request
 # in the body.
-enabled = <%= scope['::fail2ban::jails'].include? "sshd-ddos" %>
+enabled = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
 port    = ssh
 logpath = %(sshd_log)s
 

--- a/templates/Core/etc/fail2ban/jail.conf.erb
+++ b/templates/Core/etc/fail2ban/jail.conf.erb
@@ -186,7 +186,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 #
 
 [sshd]
-enabled = <%= scope['::fail2ban::jails'].include? "sshd" %>
+enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
 port    = ssh
 logpath = %(sshd_log)s
 
@@ -195,7 +195,7 @@ logpath = %(sshd_log)s
 # This jail corresponds to the standard configuration in Fail2ban.
 # The mail-whois action send a notification e-mail with a whois request
 # in the body.
-enabled = <%= scope['::fail2ban::jails'].include? "sshd-ddos" %>
+enabled = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
 port    = ssh
 logpath = %(sshd_log)s
 

--- a/templates/Final/etc/fail2ban/jail.conf.erb
+++ b/templates/Final/etc/fail2ban/jail.conf.erb
@@ -186,7 +186,7 @@ action = %(<%= scope['::fail2ban::action'] %>)s
 #
 
 [sshd]
-enabled = <%= scope['::fail2ban::jails'].include? "sshd" %>
+enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
 port    = ssh
 logpath = %(sshd_log)s
 
@@ -195,7 +195,7 @@ logpath = %(sshd_log)s
 # This jail corresponds to the standard configuration in Fail2ban.
 # The mail-whois action send a notification e-mail with a whois request
 # in the body.
-enabled = <%= scope['::fail2ban::jails'].include? "sshd-ddos" %>
+enabled = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
 port    = ssh
 logpath = %(sshd_log)s
 


### PR DESCRIPTION
#### Pull Request (PR) description

Adding the following code in the manifest:

```puppet
    class { 'fail2ban': }
```

 and deploying it on a CentOS machine will result in no jails being configured, even though the documentation mentions that **'['ssh', 'ssh-ddos']'** are configured to run by default.

The problem is that the parameters the config is looking for on the CentOS templates are **sshd** and **sshd-ddos**. 


#### This Pull Request (PR) fixes the following issues

Fixes #34 



