### PR TITLE
Remove config_file_ensure

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,6 @@ values are 'true' and 'false'. Defaults to 'true'.
 
 Determines the source of a configuration directory. Defaults to 'undef'.
 
-#### `config_file_ensure`
-
-Determines if the configuration file should be present. Valid values are 'absent'
-and 'present'. Defaults to 'present'.
-
 #### `config_file_path`
 
 Determines if the configuration file should be managed. Defaults to '/etc/fail2ban/jail.conf'


### PR DESCRIPTION
This is not a parameter to the main class and can thus be removed.

Fixes https://github.com/voxpupuli/puppet-fail2ban/issues/40