### PR TITLE
Fix CentOS 6, install EPEL before acceptance tests, add templates for Ubuntu 18.

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -2,8 +2,8 @@
 .travis.yml:
   secure: "Qvf6e0d8zyEQ2RkUFQB14wXE7dPS/+lN0WCgs79udjKp4UCRDvrIdDW6JROg5k1Kw75rQ+VuhyW2e3QXFfW65nlVrciipYlSYyA5iZaLV4ffy1NLhuscIMwuX6SNe22ut7oNB+kNfKX/rT3jnUfrg28UjJ3r4TYvzyW/e2XKx4E="
   docker_sets:
+    - set: docker/centos-6
     - set: docker/centos-7
     - set: docker/debian-8
     - set: docker/debian-9
     - set: docker/ubuntu-16.04
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,12 @@ matrix:
   - rvm: 2.4.3
     bundler_args: --without development release
     dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-6 CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.4.3
+    bundler_args: --without development release
+    dist: trusty
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/centos-7 CHECK=beaker
     services: docker
     sudo: required
@@ -71,4 +77,3 @@ deploy:
     all_branches: true
     # Only publish the build marked with "DEPLOY_TO_FORGE"
     condition: "$DEPLOY_TO_FORGE = yes"
-

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,7 +38,7 @@ class fail2ban::config {
 
   # Operating system specific configuration
   case $::operatingsystem {
-    /^(RedHat|CentOS|Scientific)$/: {
+    /^(RedHat|CentOS|Scientific|SLC)$/: {
       # Not using firewalld by now
       file { '00-firewalld.conf':
         ensure  => 'absent',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,10 +13,14 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     # Install module and dependencies
-    puppet_module_install(source: proj_root, module_name: 'fail2ban')
     hosts.each do |host|
+      if fact_on(host, 'osfamily') == 'RedHat'
+        on host, puppet('resource', 'package', 'epel-release', 'ensure=installed')
+        on host, puppet('resource', 'package', 'redhat-lsb-core', 'ensure=installed')
+      end
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0]
       on host, puppet('module', 'install', 'puppet-extlib'), acceptable_exit_codes: [0]
+      puppet_module_install(source: proj_root, module_name: 'fail2ban')
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Fixed CentOS 6 tests and ugly command line hacks for the RedHat tests. Using beaker to install the needed packages before running the acceptance tests.

Added template files for Ubuntu 18. Unfortunately, we can't enable ubuntu-18.04 tests yet, as the package needed by beaker doesn't exist.

Try running `PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=docker/ubuntu-18.04 bundle exec rake beaker` and you'll get:

```
ubuntu-1804-x64 executed in 0.48 seconds
Exited: 8

An error occurred while loading ./spec/acceptance/class_spec.rb.
Failure/Error: run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
Beaker::Host::CommandFailure:
  Host 'ubuntu-1804-x64' exited with 8 running:
   wget -O /tmp/puppet.deb http://apt.puppetlabs.com/puppetlabs-release-pc1-bionic.deb
  Last 200 lines of output were:
  	--2018-05-07 12:59:18--  http://apt.puppetlabs.com/puppetlabs-release-pc1-bionic.deb
  	Resolving apt.puppetlabs.com (apt.puppetlabs.com)... 52.222.168.15, 52.222.168.204, 52.222.168.85, ...
  	Connecting to apt.puppetlabs.com (apt.puppetlabs.com)|52.222.168.15|:80... connected.
  	HTTP request sent, awaiting response... 404 Not Found
  	2018-05-07 12:59:19 ERROR 404: Not Found.
```

Also discussed with @traylenator, including his previous PR's changes: https://github.com/voxpupuli/puppet-fail2ban/pull/54 

#### This Pull Request (PR) fixes the following issues

Fixes #36 
Fixes #57