### PR TITLE
fix default action for Debian stretch

### DIFF
--- a/templates/stretch/etc/fail2ban/jail.conf.erb
+++ b/templates/stretch/etc/fail2ban/jail.conf.erb
@@ -117,7 +117,7 @@ action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(proto
 # Choose default action.  To change, just override value of 'action' with the
 # interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
 # globally (section [DEFAULT]) or per specific section
-#action = %(<%= scope['::fail2ban::action'] %>)s
+action = %(<%= scope['::fail2ban::action'] %>)s
 
 #
 # JAILS


### PR DESCRIPTION
#### Pull Request (PR) description

there is an '#' which prevents the working configuration of a default
action. this error is not in other debian templates.

#### This Pull Request (PR) fixes the following issues
Maybe Fixes #36 