### PR TITLE
Fix action for strech template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,12 +47,10 @@ class fail2ban::config {
     }
     'Debian': {
       # Remove debian defaults conf
-      if $facts['os']['release']['major'] == '16.04' {
-        file { 'defaults-debian.conf':
-          ensure  => absent,
-          path    => "${::fail2ban::config_dir_path}/jail.d/defaults-debian.conf",
-          require => $::fail2ban::config_file_require,
-        }
+      file { 'defaults-debian.conf':
+        ensure  => absent,
+        path    => "${fail2ban::config_dir_path}/jail.d/defaults-debian.conf",
+        require => $fail2ban::config_file_require,
       }
     }
     default: {

--- a/templates/stretch/etc/fail2ban/jail.conf.erb
+++ b/templates/stretch/etc/fail2ban/jail.conf.erb
@@ -117,7 +117,7 @@ action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(proto
 # Choose default action.  To change, just override value of 'action' with the
 # interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
 # globally (section [DEFAULT]) or per specific section
-#action = %(<%= scope['::fail2ban::action'] %>)s
+action = %(<%= scope['::fail2ban::action'] %>)s
 
 #
 # JAILS
@@ -135,7 +135,7 @@ action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(proto
 # Optionally you may override any other parameter (e.g. banaction,
 # action, port, logpath, etc) in that section within jail.local
 
-[ssh]
+[sshd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ssh" %>
 port     = ssh


### PR DESCRIPTION
'action' is not working on debian strech.

This change fixes it.

This change also remove the default configuration of all Debian setup,
not only Ubuntu 16.04.