### PR TITLE
Add unit test for checking sender address

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -182,6 +182,23 @@ describe 'fail2ban' do
         it { is_expected.to contain %r{^banaction = iptables$} }
       end
     end
+
+    context 'when content template and custom sender' do
+      it 'is_expected.to work with no errors' do
+        pp = <<-EOS
+          class { 'fail2ban':
+            config_file_template => "fail2ban/#{fact('lsbdistcodename')}/#{config_file_path}.epp",
+            sender => 'custom-sender@example.com',
+          }
+        EOS
+
+        apply_manifest(pp, catch_failures: true)
+      end
+
+      describe file(config_file_path) do
+        it { is_expected.to contain %r{^sender = custom-sender@example\.com$} }
+      end
+    end
   end
 
   describe 'fail2ban::service' do


### PR DESCRIPTION
#### Pull Request (PR) description
~~The Debian Stretch template use a hardcoded sender address: `fail2ban@localhost`.~~

~~This PR use the sender address configured with `$fail2ban::sender` instead.~~

The Debian Stetch template used to have a static sender address, ignoring `$fail2ban::sender`.  This problem was addressed as a side effect of #77 but a unit-test for the correct behavior still makes sense.

#### This Pull Request (PR) fixes the following issues
n/a