### PR TITLE
Use the actual default Debian Stretch configuration for jail.conf

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/templates/stretch/etc/fail2ban/jail.conf.erb
+++ b/templates/stretch/etc/fail2ban/jail.conf.erb
@@ -2,27 +2,54 @@
 # THIS FILE IS MANAGED BY PUPPET
 # <%= file %>
 #
+# WARNING: heavily refactored in 0.9.0 release.  Please review and
+#          customize settings for your setup.
+#
+# Changes:  in most of the cases you should not modify this
+#           file, but provide customizations in jail.local file,
+#           or separate .conf files under jail.d/ directory, e.g.:
+#
+# HOW TO ACTIVATE JAILS:
+#
+# YOU SHOULD NOT MODIFY THIS FILE.
+#
+# It will probably be overwritten or improved in a distribution update.
+#
+# Provide customizations in a jail.local file or a jail.d/customisation.local.
+# For example to change the default bantime for all jails and to enable the
+# ssh-iptables jail the following (uncommented) would appear in the .local file.
+# See man 5 jail.conf for details.
+#
+# [DEFAULT]
+# bantime = 3600
+#
+# [sshd]
+# enabled = true
+#
+# See jail.conf(5) man page for more information
 
-# Fail2Ban configuration file.
-#
-# This file was composed for Debian systems from the original one
-# provided now under /usr/share/doc/fail2ban/examples/jail.conf
-# for additional examples.
-#
-# Comments: use '#' for comment lines and ';' for inline comments
-#
-# To avoid merges during upgrades DO NOT MODIFY THIS FILE
-# and rather provide your changes in /etc/fail2ban/jail.local
-#
+
+
+# Comments: use '#' for comment lines and ';' (following a space) for inline comments
+
+
+[INCLUDES]
+
+#before = paths-distro.conf
+before = paths-debian.conf
 
 # The DEFAULT allows a global definition of the options. They can be overridden
 # in each jail afterwards.
 
 [DEFAULT]
 
+#
+# MISCELLANEOUS OPTIONS
+#
+
 # "ignoreip" can be an IP address, a CIDR mask or a DNS host. Fail2ban will not
 # ban a host which matches an address in this list. Several addresses can be
-# defined using space separator.
+# defined using space (and/or comma) separator.
 ignoreip = <%= scope['::fail2ban::whitelist'].join(" ") %>
 
 # External command that will take an tagged arguments to ignore, e.g. <ip>,
@@ -36,57 +63,81 @@ bantime  = <%= scope['::fail2ban::bantime'] %>
 
 # A host is banned if it has generated "maxretry" during the last "findtime"
 # seconds.
-findtime = 600
+findtime  = 600
+
+# "maxretry" is the number of failures before a host get banned.
 maxretry = <%= scope['::fail2ban::maxretry'] %>
 
 # "backend" specifies the backend used to get files modification.
-# Available options are "pyinotify", "gamin", "polling" and "auto".
+# Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
 # This option can be overridden in each jail as well.
 #
 # pyinotify: requires pyinotify (a file alteration monitor) to be installed.
-#            If pyinotify is not installed, Fail2ban will use auto.
+#              If pyinotify is not installed, Fail2ban will use auto.
 # gamin:     requires Gamin (a file alteration monitor) to be installed.
-#            If Gamin is not installed, Fail2ban will use auto.
+#              If Gamin is not installed, Fail2ban will use auto.
 # polling:   uses a polling algorithm which does not require external libraries.
+# systemd:   uses systemd python library to access the systemd journal.
+#              Specifying "logpath" is not valid for this backend.
+#              See "journalmatch" in the jails associated filter config
 # auto:      will try to use the following backends, in order:
-#            pyinotify, gamin, polling.
+#              pyinotify, gamin, polling.
+#
+# Note: if systemd backend is chosen as the default but you enable a jail
+#       for which logs are present only in its own log files, specify some other
+#       backend for that jail (e.g. polling) and provide empty value for
+#       journalmatch. See https://github.com/fail2ban/fail2ban/issues/959#issuecomment-74901200
 backend = auto
 
 # "usedns" specifies if jails should trust hostnames in logs,
-#   warn when reverse DNS lookups are performed, or ignore all hostnames in logs
+#   warn when DNS lookups are performed, or ignore all hostnames in logs
 #
-# yes:   if a hostname is encountered, a reverse DNS lookup will be performed.
-# warn:  if a hostname is encountered, a reverse DNS lookup will be performed,
+# yes:   if a hostname is encountered, a DNS lookup will be performed.
+# warn:  if a hostname is encountered, a DNS lookup will be performed,
 #        but it will be logged as a warning.
 # no:    if a hostname is encountered, will not be used for banning,
 #        but it will be logged as info.
+# raw:   use raw value (no hostname), allow use it for no-host filters/actions (example user)
 usedns = warn
 
+# "logencoding" specifies the encoding of the log files handled by the jail
+#   This is used to decode the lines from the log file.
+#   Typical examples:  "ascii", "utf-8"
 #
-# Destination email address used solely for the interpolations in
-# jail.{conf,local} configuration files.
-destemail = <%= scope['::fail2ban::email'] %>
+#   auto:   will use the system locale setting
+logencoding = auto
 
+# "enabled" enables the jails.
+#  By default all jails are disabled, and it should stay this way.
+#  Enable only relevant to your setup jails in your .local or jail.d/*.conf
 #
-# Name of the sender for mta actions
-sendername = Fail2Ban
+# true:  jail will be enabled and log files will get monitored for changes
+# false: jail is not enabled
+enabled = false
 
-# Email address of the sender
-sender = fail2ban@localhost
+
+# "filter" defines the filter to use by the jail.
+#  By default jails have names matching their filter name
+#
+filter = %(__name__)s
+
 
 #
 # ACTIONS
 #
 
-# Default banning action (e.g. iptables, iptables-new,
-# iptables-multiport, shorewall, etc) It is used to define
-# action_* variables. Can be overridden globally or per
-# section within jail.local file
-banaction = <%= scope['::fail2ban::banaction'] %>
+# Some options used for actions
 
-# email action. Since 0.8.1 upstream fail2ban uses sendmail
-# MTA for the mailing. Change mta configuration parameter to mail
-# if you want to revert to conventional 'mail'.
+# Destination email address used solely for the interpolations in
+# jail.{conf,local,d/*} configuration files.
+destemail = <%= scope['::fail2ban::email'] %>
+
+# Sender email address used solely for some actions
+sender = <%= scope['::fail2ban::sender'] %>
+
+# E-mail action. Since 0.8.1 Fail2Ban uses sendmail MTA for the
+# mailing. Change mta configuration parameter to mail if you want to
+# revert to conventional 'mail'.
 mta = sendmail
 
 # Default protocol
@@ -95,182 +146,225 @@ protocol = tcp
 # Specify chain where jumps would need to be added in iptables-* actions
 chain = <%= scope['::fail2ban::iptables_chain'] %>
 
+# Ports to be banned
+# Usually should be overridden in a particular jail
+port = 0:65535
+
+# Format of user-agent https://tools.ietf.org/html/rfc7231#section-5.5.3
+fail2ban_agent = Fail2Ban/%(fail2ban_version)s
+
 #
 # Action shortcuts. To be used to define action parameter
 
-# The simplest action to take: ban only
-action_ = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+# Default banning action (e.g. iptables, iptables-new,
+# iptables-multiport, shorewall, etc) It is used to define
+# action_* variables. Can be overridden globally or per
+# section within jail.local file
+banaction = <%= scope['::fail2ban::banaction'] %>
+banaction_allports = iptables-allports
 
-# ban & send an e-mail with buffered report to the destemail.
-action_mb = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
-              %(mta)s-buffered[name=%(__name__)s, dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s", sendername="%(sendername)s"]
+# The simplest action to take: ban only
+action_ = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
 
 # ban & send an e-mail with whois report to the destemail.
-action_mw = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
-              %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s", sendername="%(sendername)s"]
+action_mw = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+            %(mta)s-whois[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
 
 # ban & send an e-mail with whois report and relevant log lines
 # to the destemail.
-action_mwl = %(banaction)s[name=%(__name__)s, port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
-               %(mta)s-whois-lines[name=%(__name__)s, dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s", sendername="%(sendername)s"]
+action_mwl = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+             %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+
+# See the IMPORTANT note in action.d/xarf-login-attack for when to use this action
+#
+# ban & send a xarf e-mail to abuse contact of IP address and include relevant log lines
+# to the destemail.
+action_xarf = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+             xarf-login-attack[service=%(__name__)s, sender="%(sender)s", logpath=%(logpath)s, port="%(port)s"]
+
+# ban IP on CloudFlare & send an e-mail with whois report and relevant log lines
+# to the destemail.
+action_cf_mwl = cloudflare[cfuser="%(cfemail)s", cftoken="%(cfapikey)s"]
+                %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+
+# Report block via blocklist.de fail2ban reporting service API
+# 
+# See the IMPORTANT note in action.d/blocklist_de.conf for when to
+# use this action. Create a file jail.d/blocklist_de.local containing
+# [Init]
+# blocklist_de_apikey = {api key from registration]
+#
+action_blocklist_de  = blocklist_de[email="%(sender)s", service=%(filter)s, apikey="%(blocklist_de_apikey)s", agent="%(fail2ban_agent)s"]
+
+# Report ban via badips.com, and use as blacklist
+#
+# See BadIPsAction docstring in config/action.d/badips.py for
+# documentation for this action.
+#
+# NOTE: This action relies on banaction being present on start and therefore
+# should be last action defined for a jail.
+#
+action_badips = badips.py[category="%(__name__)s", banaction="%(banaction)s", agent="%(fail2ban_agent)s"]
+#
+# Report ban via badips.com (uses action.d/badips.conf for reporting only)
+#
+action_badips_report = badips[category="%(__name__)s", agent="%(fail2ban_agent)s"]
 
 # Choose default action.  To change, just override value of 'action' with the
 # interpolation to the chosen action shortcut (e.g.  action_mw, action_mwl, etc) in jail.local
 # globally (section [DEFAULT]) or per specific section
 action = %(<%= scope['::fail2ban::action'] %>)s
 
+
 #
 # JAILS
 #
 
-# Next jails corresponds to the standard configuration in Fail2ban 0.6 which
-# was shipped in Debian. Enable any defined here jail by including
 #
-# [SECTION_NAME]
-# enabled = true
-
+# SSH servers
 #
-# in /etc/fail2ban/jail.local.
-#
-# Optionally you may override any other parameter (e.g. banaction,
-# action, port, logpath, etc) in that section within jail.local
 
 [sshd]
 
-enabled  = <%= scope['::fail2ban::jails'].include? "ssh" %>
-port     = ssh
-filter   = sshd
-logpath  = /var/log/auth.log
-maxretry = 6
+enabled = <%= scope['::fail2ban::jails'].include? "ssh" %>
+port    = ssh
+logpath = %(sshd_log)s
+backend = %(sshd_backend)s
+
+
+[sshd-ddos]
+# This jail corresponds to the standard configuration in Fail2ban.
+# The mail-whois action send a notification e-mail with a whois request
+# in the body.
+enabled = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
+port    = ssh
+logpath = %(sshd_log)s
+backend = %(sshd_backend)s
+
 
 [dropbear]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "dropbear" %>
 port     = ssh
-filter   = dropbear
-logpath  = /var/log/auth.log
-maxretry = 6
-
-# Generic filter for pam. Has to be used with action which bans all ports
-# such as iptables-allports, shorewall
-[pam-generic]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "pam-generic" %>
-# pam-generic filter can be customized to monitor specific subset of 'tty's
-filter   = pam-generic
-# port actually must be irrelevant but lets leave it all for some possible uses
-port     = all
-banaction = iptables-allports
-logpath  = /var/log/auth.log
-maxretry = 6
-
-[xinetd-fail]
-
-enabled   = <%= scope['::fail2ban::jails'].include? "xinetd-fail" %>
-filter    = xinetd-fail
-port      = all
-banaction = iptables-multiport-log
-logpath   = /var/log/daemon.log
-maxretry  = 2
+logpath  = %(dropbear_log)s
+backend  = %(dropbear_backend)s
 
 
-[ssh-ddos]
+[selinux-ssh]
 
-enabled  = <%= scope['::fail2ban::jails'].include? "ssh-ddos" %>
+enabled  = <%= scope['::fail2ban::jails'].include? "selinux-ssh" %>
 port     = ssh
-filter   = sshd-ddos
-logpath  = /var/log/auth.log
-maxretry = 6
-
-
-# Here we use blackhole routes for not requiring any additional kernel support
-# to store large volumes of banned IPs
-
-[ssh-route]
-
-enabled = <%= scope['::fail2ban::jails'].include? "ssh-route" %>
-filter = sshd
-action = route
-logpath = /var/log/sshd.log
-maxretry = 6
-
-# Here we use a combination of Netfilter/Iptables and IPsets
-# for storing large volumes of banned IPs
-#
-# IPset comes in two versions. See ipset -V for which one to use
-# requires the ipset package and kernel support.
-[ssh-iptables-ipset4]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "ssh-iptables-ipset4" %>
-port     = ssh
-filter   = sshd
-banaction = iptables-ipset-proto4
-logpath  = /var/log/sshd.log
-maxretry = 6
-
-[ssh-iptables-ipset6]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "ssh-iptables-ipset6" %>
-port     = ssh
-filter   = sshd
-banaction = iptables-ipset-proto6
-logpath  = /var/log/sshd.log
-maxretry = 6
+logpath  = %(auditd_log)s
 
 
 #
 # HTTP servers
 #
 
-[apache]
+[apache-auth]
 
-enabled  = <%= scope['::fail2ban::jails'].include? "apache" %>
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-auth" %>
 port     = http,https
-filter   = apache-auth
-logpath  = /var/log/apache*/*error.log
-maxretry = 6
+logpath  = %(apache_error_log)s
 
-# default action is now multiport, so apache-multiport jail was left
-# for compatibility with previous (<0.7.6-2) releases
-[apache-multiport]
 
-enabled   = <%= scope['::fail2ban::jails'].include? "apache-multiport" %>
-port      = http,https
-filter    = apache-auth
-logpath   = /var/log/apache*/*error.log
-maxretry  = 6
+[apache-badbots]
+# Ban hosts which agent identifies spammer robots crawling the web
+# for email addresses. The mail outputs are buffered.
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-badbots" %>
+port     = http,https
+logpath  = %(apache_access_log)s
+bantime  = 172800
+maxretry = 1
+
 
 [apache-noscript]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-noscript" %>
 port     = http,https
-filter   = apache-noscript
-logpath  = /var/log/apache*/*error.log
-maxretry = 6
+logpath  = %(apache_error_log)s
+
 
 [apache-overflows]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-overflows" %>
 port     = http,https
-filter   = apache-overflows
-logpath  = /var/log/apache*/*error.log
+logpath  = %(apache_error_log)s
 maxretry = 2
 
-[apache-modsecurity]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
-filter   = apache-modsecurity
-port     = http,https
-logpath  = /var/log/apache*/*error.log
-maxretry = 2
 
 [apache-nohome]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "apache-nohome" %>
-filter   = apache-nohome
 port     = http,https
-logpath  = /var/log/apache*/*error.log
+logpath  = %(apache_error_log)s
 maxretry = 2
+
+
+[apache-botsearch]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-botsearch" %>
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+
+[apache-fakegooglebot]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-fakegooglebot" %>
+port     = http,https
+logpath  = %(apache_access_log)s
+maxretry = 1
+ignorecommand = %(ignorecommands_dir)s/apache-fakegooglebot <ip>
+
+
+[apache-modsecurity]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-modsecurity" %>
+port     = http,https
+logpath  = %(apache_error_log)s
+maxretry = 2
+
+
+[apache-shellshock]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "apache-shellshock" %>
+port    = http,https
+logpath = %(apache_error_log)s
+maxretry = 1
+
+
+[openhab-auth]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "openhab-auth" %>
+filter = openhab
+action = iptables-allports[name=NoAuthFailures]
+logpath = /opt/openhab/logs/request.log
+
+
+[nginx-http-auth]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
+port    = http,https
+logpath = %(nginx_error_log)s
+
+# To use 'nginx-limit-req' jail you should have `ngx_http_limit_req_module` 
+# and define `limit_req` and `limit_req_zone` as described in nginx documentation
+# http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
+# or for example see in 'config/filter.d/nginx-limit-req.conf'
+[nginx-limit-req]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "nginx-limit-req" %>
+port    = http,https
+logpath = %(nginx_error_log)s
+
+[nginx-botsearch]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "nginx-botsearch" %>
+port     = http,https
+logpath  = %(nginx_error_log)s
+maxretry = 2
+
 
 # Ban attackers that try to use PHP's URL-fopen() functionality
 # through GET/POST variables. - Experimental, with more than a year
@@ -280,120 +374,286 @@ maxretry = 2
 
 enabled = <%= scope['::fail2ban::jails'].include? "php-url-fopen" %>
 port    = http,https
-filter  = php-url-fopen
-logpath = /var/www/*/logs/access_log
+logpath = %(nginx_access_log)s
+          %(apache_access_log)s
 
-# A simple PHP-fastcgi jail which works with lighttpd.
-# If you run a lighttpd server, then you probably will
-# find these kinds of messages in your error_log:
-#   ALERT – tried to register forbidden variable ‘GLOBALS’
-#   through GET variables (attacker '1.2.3.4', file '/var/www/default/htdocs/index.php')
 
-[lighttpd-fastcgi]
+[suhosin]
 
-enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-fastcgi" %>
+enabled = <%= scope['::fail2ban::jails'].include? "suhosin" %>
 port    = http,https
-filter  = lighttpd-fastcgi
-logpath = /var/log/lighttpd/error.log
+logpath = %(suhosin_log)s
 
-# Same as above for mod_auth
-# It catches wrong authentifications
 
 [lighttpd-auth]
-
+# Same as above for Apache's mod_auth
+# It catches wrong authentifications
 enabled = <%= scope['::fail2ban::jails'].include? "lighttpd-auth" %>
 port    = http,https
-filter  = suhosin
-logpath = /var/log/lighttpd/error.log
+logpath = %(lighttpd_error_log)s
 
-[nginx-http-auth]
 
-enabled = <%= scope['::fail2ban::jails'].include? "nginx-http-auth" %>
-filter  = nginx-http-auth
-port    = http,https
-logpath = /var/log/nginx/*error*.log
+#
+# Webmail and groupware servers
+#
 
-# Monitor roundcube server
 [roundcube-auth]
 
-enabled  = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
-filter   = roundcube-auth
+enabled = <%= scope['::fail2ban::jails'].include? "roundcube-auth" %>
 port     = http,https
-logpath  = /var/log/roundcube/userlogins
+logpath  = %(roundcube_errors_log)s
+
+
+[openwebmail]
+
+enabled = <%= scope['::fail2ban::jails'].include? "openwebmail" %>
+port     = http,https
+logpath  = /var/log/openwebmail.log
+
+
+[horde]
+
+enabled = <%= scope['::fail2ban::jails'].include? "horde" %>
+port     = http,https
+logpath  = /var/log/horde/horde.log
+
+
+[groupoffice]
+
+enabled = <%= scope['::fail2ban::jails'].include? "groupoffice" %>
+port     = http,https
+logpath  = /home/groupoffice/log/info.log
 
 
 [sogo-auth]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
-filter   = sogo-auth
-port     = http, https
+# Monitor SOGo groupware server
 # without proxy this would be:
 # port    = 20000
+enabled = <%= scope['::fail2ban::jails'].include? "sogo-auth" %>
+port     = http,https
 logpath  = /var/log/sogo/sogo.log
+
+
+[tine20]
+
+enabled = <%= scope['::fail2ban::jails'].include? "tine20" %>
+logpath  = /var/log/tine20/tine20.log
+port     = http,https
+
+
+#
+# Web Applications
+#
+#
+
+[drupal-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "drupal-auth" %>
+port     = http,https
+logpath  = %(syslog_daemon)s
+backend  = %(syslog_backend)s
+
+[guacamole]
+
+enabled = <%= scope['::fail2ban::jails'].include? "guacamole" %>
+port     = http,https
+logpath  = /var/log/tomcat*/catalina.out
+
+[monit]
+#Ban clients brute-forcing the monit gui login
+enabled = <%= scope['::fail2ban::jails'].include? "monit" %>
+port = 2812
+logpath  = /var/log/monit
+
+
+[webmin-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "webmin-auth" %>
+port    = 10000
+logpath = %(syslog_authpriv)s
+backend = %(syslog_backend)s
+
+
+[froxlor-auth]
+
+enabled = <%= scope['::fail2ban::jails'].include? "froxlor-auth" %>
+port    = http,https
+logpath  = %(syslog_authpriv)s
+backend  = %(syslog_backend)s
+
+
+#
+# HTTP Proxy servers
+#
+#
+
+[squid]
+
+enabled = <%= scope['::fail2ban::jails'].include? "squid" %>
+port     =  80,443,3128,8080
+logpath = /var/log/squid/access.log
+
+
+[3proxy]
+
+enabled = <%= scope['::fail2ban::jails'].include? "3proxy" %>
+port    = 3128
+logpath = /var/log/3proxy.log
 
 
 #
 # FTP servers
 #
 
-[vsftpd]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
-port     = ftp,ftp-data,ftps,ftps-data
-filter   = vsftpd
-logpath  = /var/log/vsftpd.log
-# or overwrite it in jails.local to be
-# logpath = /var/log/auth.log
-# if you want to rely on PAM failed login attempts
-# vsftpd's failregex should match both of those formats
-maxretry = 6
-
 
 [proftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "proftpd" %>
 port     = ftp,ftp-data,ftps,ftps-data
-filter   = proftpd
-logpath  = /var/log/proftpd/proftpd.log
-maxretry = 6
+logpath  = %(proftpd_log)s
+backend  = %(proftpd_backend)s
 
 
 [pure-ftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "pure-ftpd" %>
 port     = ftp,ftp-data,ftps,ftps-data
-filter   = pure-ftpd
-logpath  = /var/log/syslog
-maxretry = 6
+logpath  = %(pureftpd_log)s
+backend  = %(pureftpd_backend)s
+
+
+[gssftpd]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "gssftpd" %>
+port     = ftp,ftp-data,ftps,ftps-data
+logpath  = %(syslog_daemon)s
+backend  = %(syslog_backend)s
 
 
 [wuftpd]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "wuftpd" %>
 port     = ftp,ftp-data,ftps,ftps-data
-filter   = wuftpd
-logpath  = /var/log/syslog
-maxretry = 6
+logpath  = %(wuftpd_log)s
+backend  = %(wuftpd_backend)s
+
+
+[vsftpd]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "vsftpd" %>
+# or overwrite it in jails.local to be
+# logpath = %(syslog_authpriv)s
+# if you want to rely on PAM failed login attempts
+# vsftpd's failregex should match both of those formats
+port     = ftp,ftp-data,ftps,ftps-data
+logpath  = %(vsftpd_log)s
 
 
 #
 # Mail servers
 #
 
+# ASSP SMTP Proxy Jail
+[assp]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "assp" %>
+port     = smtp,465,submission
+logpath  = /root/path/to/assp/logs/maillog.txt
+
+
+[courier-smtp]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "courier-smtp" %>
+port     = smtp,465,submission
+logpath  = %(syslog_mail)s
+backend  = %(syslog_backend)s
+
+
 [postfix]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix" %>
-port     = smtp,ssmtp,submission
-filter   = postfix
-logpath  = /var/log/mail.log
+port     = smtp,465,submission
+logpath  = %(postfix_log)s
+backend  = %(postfix_backend)s
 
 
-[couriersmtp]
+[postfix-rbl]
 
-enabled  = <%= scope['::fail2ban::jails'].include? "couriersmtp" %>
-port     = smtp,ssmtp,submission
-filter   = couriersmtp
-logpath  = /var/log/mail.log
+enabled  = <%= scope['::fail2ban::jails'].include? "postfix-rbl" %>
+port     = smtp,465,submission
+logpath  = %(postfix_log)s
+backend  = %(postfix_backend)s
+maxretry = 1
+
+
+[sendmail-auth]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "sendmail-auth" %>
+port    = submission,465,smtp
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
+[sendmail-reject]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "sendmail-reject" %>
+port     = smtp,465,submission
+logpath  = %(syslog_mail)s
+backend  = %(syslog_backend)s
+
+
+[qmail-rbl]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "qmail-rbl" %>
+filter  = qmail
+port    = smtp,465,submission
+logpath = /service/qmail/log/main/current
+
+
+# dovecot defaults to logging to the mail syslog facility
+# but can be set by syslog_facility in the dovecot configuration.
+[dovecot]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "dovecot" %>
+port    = pop3,pop3s,imap,imaps,submission,465,sieve
+logpath = %(dovecot_log)s
+backend = %(dovecot_backend)s
+
+
+[sieve]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "sieve" %>
+port   = smtp,465,submission
+logpath = %(dovecot_log)s
+backend = %(dovecot_backend)s
+
+
+[solid-pop3d]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "solid-pop3d" %>
+port    = pop3,pop3s
+logpath = %(solidpop3d_log)s
+
+
+[exim]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "exim" %>
+port   = smtp,465,submission
+logpath = %(exim_main_log)s
+
+
+[exim-spam]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "exim-spam" %>
+port   = smtp,465,submission
+logpath = %(exim_main_log)s
+
+
+[kerio]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "kerio" %>
+port    = imap,smtp,imaps,465
+logpath = /opt/kerio/mailserver/store/logs/security.log
 
 
 #
@@ -401,60 +661,61 @@ logpath  = /var/log/mail.log
 # all relevant ports get banned
 #
 
-[courierauth]
+[courier-auth]
 
-enabled  = <%= scope['::fail2ban::jails'].include? "courierauth" %>
-port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
-filter   = courierlogin
-logpath  = /var/log/mail.log
+enabled  = <%= scope['::fail2ban::jails'].include? "courier-auth" %>
+port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+logpath  = %(syslog_mail)s
+backend  = %(syslog_backend)s
 
 
-[sasl]
+[postfix-sasl]
 
-enabled  = <%= scope['::fail2ban::jails'].include? "sasl" %>
-port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
-filter   = postfix-sasl
+enabled  = <%= scope['::fail2ban::jails'].include? "postfix-sasl" %>
+port     = smtp,465,submission,imap3,imaps,pop3,pop3s
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
-logpath  = /var/log/mail.log
-
-[dovecot]
-
-enabled = <%= scope['::fail2ban::jails'].include? "dovecot" %>
-port    = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
-filter  = dovecot
-logpath = /var/log/mail.log
-
-# To log wrong MySQL access attempts add to /etc/my.cnf:
-# log-error=/var/log/mysqld.log
-# log-warning = 2
-[mysqld-auth]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
-filter   = mysqld-auth
-port     = 3306
-logpath  = /var/log/mysqld.log
+logpath  = %(postfix_log)s
+backend  = %(postfix_backend)s
 
 
-# DNS Servers
+[perdition]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "perdition" %>
+port   = imap3,imaps,pop3,pop3s
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
 
 
-# These jails block attacks against named (bind9). By default, logging is off
-# with bind9 installation. You will need something like this:
+[squirrelmail]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "squirrelmail" %>
+port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
+
+
+[cyrus-imap]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "cyrus-imap" %>
+port   = imap3,imaps
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
+[uwimap-auth]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "uwimap-auth" %>
+port   = imap3,imaps
+logpath = %(syslog_mail)s
+backend = %(syslog_backend)s
+
+
 #
-# logging {
-#     channel security_file {
-#         file "/var/log/named/security.log" versions 3 size 30m;
-#         severity dynamic;
-#         print-time yes;
-#     };
-#     category security {
-#         security_file;
-#     };
-# };
 #
-# in your named.conf to provide proper logging
+# DNS servers
+#
+
 
 # !!! WARNING !!!
 #   Since UDP is connection-less protocol, spoofing of IP and imitation
@@ -463,150 +724,218 @@ logpath  = /var/log/mysqld.log
 #   victim. See
 #    http://nion.modprobe.de/blog/archives/690-fail2ban-+-dns-fail.html
 #   Please DO NOT USE this jail unless you know what you are doing.
-#[named-refused-udp]
 #
-#enabled  = false
-#port     = domain,953
-#protocol = udp
-#filter   = named-refused
-#logpath  = /var/log/named/security.log
+# IMPORTANT: see filter.d/named-refused for instructions to enable logging
+# This jail blocks UDP traffic for DNS requests.
+# [named-refused-udp]
+#
+# filter   = named-refused
+# port     = domain,953
+# protocol = udp
+# logpath  = /var/log/named/security.log
 
-[named-refused-tcp]
+# IMPORTANT: see filter.d/named-refused for instructions to enable logging
+# This jail blocks TCP traffic for DNS requests.
 
-enabled  = <%= scope['::fail2ban::jails'].include? "named-refused-tcp" %>
+[named-refused]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "named-refused" %>
 port     = domain,953
-protocol = tcp
-filter   = named-refused
 logpath  = /var/log/named/security.log
+
+
+[nsd]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "nsd" %>
+port     = 53
+action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+logpath = /var/log/nsd.log
+
+
+#
+# Miscellaneous
+#
+
+[asterisk]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "asterisk" %>
+port     = 5060,5061
+action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+logpath  = /var/log/asterisk/messages
+maxretry = 10
+
 
 [freeswitch]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "freeswitch" %>
-filter   = freeswitch
+port     = 5060,5061
+action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
 logpath  = /var/log/freeswitch.log
 maxretry = 10
-action   = iptables-multiport[name=freeswitch-tcp, port="5060,5061,5080,5081", protocol=tcp]
-           iptables-multiport[name=freeswitch-udp, port="5060,5061,5080,5081", protocol=udp]
+
+
+# To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld] or
+# equivalent section:
+# log-warning = 2
+#
+# for syslog (daemon facility)
+# [mysqld_safe]
+# syslog
+#
+# for own logfile
+# [mysqld]
+# log-error=/var/log/mysqld.log
+[mysqld-auth]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "mysqld-auth" %>
+port     = 3306
+logpath  = %(mysql_log)s
+backend  = %(mysql_backend)s
+
+
+# Log wrong MongoDB auth (for details see filter 'filter.d/mongodb-auth.conf')
+[mongodb-auth]
+# change port when running with "--shardsvr" or "--configsvr" runtime operation
+enabled  = <%= scope['::fail2ban::jails'].include? "mongodb-auth" %>
+port     = 27017
+logpath  = /var/log/mongodb/mongodb.log
+
+
+# Jail for more extended banning of persistent abusers
+# !!! WARNINGS !!!
+# 1. Make sure that your loglevel specified in fail2ban.conf/.local
+#    is not at DEBUG level -- which might then cause fail2ban to fall into
+#    an infinite loop constantly feeding itself with non-informative lines
+# 2. Increase dbpurgeage defined in fail2ban.conf to e.g. 648000 (7.5 days)
+#    to maintain entries for failed logins for sufficient amount of time
+[recidive]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "recidive" %>
+logpath  = /var/log/fail2ban.log
+banaction = %(banaction_allports)s
+bantime  = 604800  ; 1 week
+findtime = 86400   ; 1 day
+
+
+# Generic filter for PAM. Has to be used with action which bans all
+# ports such as iptables-allports, shorewall
+
+[pam-generic]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "pam-generic" %>
+# pam-generic filter can be customized to monitor specific subset of 'tty's
+banaction = %(banaction_allports)s
+logpath  = %(syslog_authpriv)s
+backend  = %(syslog_backend)s
+
+
+[xinetd-fail]
+
+enabled   = <%= scope['::fail2ban::jails'].include? "xinetd-fail" %>
+banaction = iptables-multiport-log
+logpath   = %(syslog_daemon)s
+backend   = %(syslog_backend)s
+maxretry  = 2
+
+
+# stunnel - need to set port for this
+[stunnel]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "stunnel" %>
+logpath = /var/log/stunnel4/stunnel.log
+
 
 [ejabberd-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "ejabberd-auth" %>
-filter   = ejabberd-auth
-port     = xmpp-client
-protocol = tcp
-logpath  = /var/log/ejabberd/ejabberd.log
+port    = 5222
+logpath = /var/log/ejabberd/ejabberd.log
 
 
-# Multiple jails, 1 per protocol, are necessary ATM:
-# see https://github.com/fail2ban/fail2ban/issues/37
-[asterisk-tcp]
+[counter-strike]
 
-enabled  = <%= scope['::fail2ban::jails'].include? "asterisk-tcp" %>
-filter   = asterisk
-port     = 5060,5061
-protocol = tcp
-logpath  = /var/log/asterisk/messages
-
-[asterisk-udp]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "asterisk-udp" %>
-filter	 = asterisk
-port     = 5060,5061
-protocol = udp
-logpath  = /var/log/asterisk/messages
-
-
-# Jail for more extended banning of persistent abusers
-# !!! WARNING !!!
-#   Make sure that your loglevel specified in fail2ban.conf/.local
-#   is not at DEBUG level -- which might then cause fail2ban to fall into
-#   an infinite loop constantly feeding itself with non-informative lines
-[recidive]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "recidive" %>
-filter   = recidive
-logpath  = /var/log/fail2ban.log
-action   = iptables-allports[name=recidive]
-           sendmail-whois-lines[name=recidive, logpath=/var/log/fail2ban.log]
-bantime  = 604800  ; 1 week
-findtime = 86400   ; 1 day
-maxretry = 5
-
-# See the IMPORTANT note in action.d/blocklist_de.conf for when to
-# use this action
-#
-# Report block via blocklist.de fail2ban reporting service API
-# See action.d/blocklist_de.conf for more information
-[ssh-blocklist]
-
-enabled  = <%= scope['::fail2ban::jails'].include? "ssh-blocklist" %>
-filter   = sshd
-action   = iptables[name=SSH, port=ssh, protocol=tcp]
-           sendmail-whois[name=SSH, dest="%(destemail)s", sender="%(sender)s", sendername="%(sendername)s"]
-           blocklist_de[email="%(sender)s", apikey="xxxxxx", service="%(filter)s"]
-logpath  = /var/log/sshd.log
-maxretry = 20
-
+enabled  = <%= scope['::fail2ban::jails'].include? "counter-strike" %>
+logpath = /opt/cstrike/logs/L[0-9]*.log
+# Firewall: http://www.cstrike-planet.com/faq/6
+tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
+udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
+action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
 
 # consider low maxretry and a long bantime
 # nobody except your own Nagios server should ever probe nrpe
 [nagios]
+
 enabled  = <%= scope['::fail2ban::jails'].include? "nagios" %>
-filter   = nagios
-action   = iptables[name=Nagios, port=5666, protocol=tcp]
-           sendmail-whois[name=Nagios, dest="%(destemail)s", sender="%(sender)s", sendername="%(sendername)s"]
-logpath  = /var/log/messages     ; nrpe.cfg may define a different log_facility
+logpath  = %(syslog_daemon)s     ; nrpe.cfg may define a different log_facility
+backend  = %(syslog_backend)s
 maxretry = 1
 
 
-<% if @additional_jails -%>
-#
-# Additional jails
-#
+[oracleims]
+# see "oracleims" filter file for configuration requirement for Oracle IMS v6 and above
+enabled  = <%= scope['::fail2ban::jails'].include? "oracleims" %>
+logpath = /opt/sun/comms/messaging64/log/mail.log_current
+banaction = %(banaction_allports)s
 
-# wordpress login failures using nginx
-[nginx-wp-login]
-enabled = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-wp-login" %>
-port = http,https
-filter = nginx-wp-login
-logpath = /var/log/nginx/access.log
-maxretry = 3
-findtime = 120
-bantime = 1200
+[directadmin]
 
-# nginx login failures
-[nginx-login]
-enabled = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-login" %>
-filter = nginx-login
-action = iptables-multiport[name=NoLoginFailures, port="http,https"]
-logpath = /var/log/nginx*/*access*.log
-bantime = 600 # 10 minutes
-maxretry = 6
+enabled  = <%= scope['::fail2ban::jails'].include? "directadmin" %>
+logpath = /var/log/directadmin/login.log
+port = 2222
 
-# nginx badbots
-[nginx-badbots]
-enabled  = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-badbots" %>
-filter = apache-badbots
-action = iptables-multiport[name=BadBots, port="http,https"]
-logpath = /var/log/nginx*/*access*.log
-bantime = 86400 # 1 day
+[portsentry]
+
+enabled  = <%= scope['::fail2ban::jails'].include? "portsentry" %>
+logpath  = /var/lib/portsentry/portsentry.history
 maxretry = 1
 
-# IPs trying to execute scripts
-[nginx-noscript]
-enabled = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-noscript" %>
-action = iptables-multiport[name=NoScript, port="http,https"]
-filter = nginx-noscript
-logpath = /var/log/nginx*/*access*.log
-maxretry = 6
-bantime  = 86400 # 1 day
+[pass2allow-ftp]
+# this pass2allow example allows FTP traffic after successful HTTP authentication
+enabled  = <%= scope['::fail2ban::jails'].include? "pass2allow-ftp" %>
+port         = ftp,ftp-data,ftps,ftps-data
+# knocking_url variable must be overridden to some secret value in jail.local
+knocking_url = /knocking/
+filter       = apache-pass[knocking_url="%(knocking_url)s"]
+# access log of the website with HTTP auth
+logpath      = %(apache_access_log)s
+blocktype    = RETURN
+returntype   = DROP
+bantime      = 3600
+maxretry     = 1
+findtime     = 1
 
-# IPs trying to use server as proxy.
-[nginx-proxy]
-enabled = <%= scope.lookupvar('::fail2ban::jails').include? "nginx-proxy" %>
-action = iptables-multiport[name=NoProxy, port="http,https"]
-filter = nginx-proxy
-logpath = /var/log/nginx*/*access*.log
-maxretry = 0
-bantime  = 86400 # 1 day
-<% end -%>
+
+[murmur]
+# AKA mumble-server
+enabled  = <%= scope['::fail2ban::jails'].include? "murmur" %>
+port     = 64738
+action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol=tcp, chain="%(chain)s", actname=%(banaction)s-tcp]
+           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol=udp, chain="%(chain)s", actname=%(banaction)s-udp]
+logpath  = /var/log/mumble-server/mumble-server.log
+
+
+[screensharingd]
+# For Mac OS Screen Sharing Service (VNC)
+enabled  = <%= scope['::fail2ban::jails'].include? "screensharingd" %>
+logpath  = /var/log/system.log
+logencoding = utf-8
+
+[haproxy-http-auth]
+# HAProxy by default doesn't log to file you'll need to set it up to forward
+# logs to a syslog server which would then write them to disk.
+# See "haproxy-http-auth" filter for a brief cautionary note when setting
+# maxretry and findtime.
+enabled  = <%= scope['::fail2ban::jails'].include? "haproxy-http-auth" %>
+logpath  = /var/log/haproxy.log
+
+[slapd]
+enabled  = <%= scope['::fail2ban::jails'].include? "slapd" %>
+port    = ldap,ldaps
+filter  = slapd
+logpath = /var/log/slapd.log

--- a/templates/stretch/etc/fail2ban/jail.conf.erb
+++ b/templates/stretch/etc/fail2ban/jail.conf.erb
@@ -166,6 +166,10 @@ banaction_allports = iptables-allports
 # The simplest action to take: ban only
 action_ = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
 
+# ban & send an e-mail with buffered report to the destemail.
+action_mb = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+            %(mta)s-buffered[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
+
 # ban & send an e-mail with whois report to the destemail.
 action_mw = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
             %(mta)s-whois[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]

--- a/templates/stretch/etc/fail2ban/jail.conf.erb
+++ b/templates/stretch/etc/fail2ban/jail.conf.erb
@@ -668,7 +668,7 @@ logpath = /opt/kerio/mailserver/store/logs/security.log
 [courier-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "courier-auth" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = smtp,465,submission,imap,imaps,pop3,pop3s
 logpath  = %(syslog_mail)s
 backend  = %(syslog_backend)s
 
@@ -676,7 +676,7 @@ backend  = %(syslog_backend)s
 [postfix-sasl]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "postfix-sasl" %>
-port     = smtp,465,submission,imap3,imaps,pop3,pop3s
+port     = smtp,465,submission,imap,imaps,pop3,pop3s
 # You might consider monitoring /var/log/mail.warn instead if you are
 # running postfix since it would provide the same log lines at the
 # "warn" level but overall at the smaller filesize.
@@ -687,7 +687,7 @@ backend  = %(postfix_backend)s
 [perdition]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "perdition" %>
-port   = imap3,imaps,pop3,pop3s
+port   = imap,imaps,pop3,pop3s
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
 
@@ -695,14 +695,14 @@ backend = %(syslog_backend)s
 [squirrelmail]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "squirrelmail" %>
-port = smtp,465,submission,imap2,imap3,imaps,pop3,pop3s,http,https,socks
+port = smtp,465,submission,imap2,imap,imaps,pop3,pop3s,http,https,socks
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
 [cyrus-imap]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "cyrus-imap" %>
-port   = imap3,imaps
+port   = imap,imaps
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
 
@@ -710,7 +710,7 @@ backend = %(syslog_backend)s
 [uwimap-auth]
 
 enabled  = <%= scope['::fail2ban::jails'].include? "uwimap-auth" %>
-port   = imap3,imaps
+port   = imap,imaps
 logpath = %(syslog_mail)s
 backend = %(syslog_backend)s
 


### PR DESCRIPTION

#### Pull Request (PR) description

While trying to fix a problem with the Debian Stretch template ([imap3 port is not defined in Debian Stretch](https://github.com/fail2ban/fail2ban/issues/1942)), I realized that the default template of `jail.conf` on Debian Stretch is a slightly modified version of the default template for Debian Jessie, and not the actual default files provided in Debian Stretch.

As stated in this configuration file, `jail.conf` has been *heavily refactored in 0.9.0 release*.

This pull-request integrates the actual default template, adjusted to allow customization through the module.

In order to ease-up reviewing, [here is a diff between the original file as provided in the Debian package and the template included in this PR](https://gist.github.com/smortex/9f2ac096a8c904c4c257ceb549a714bd).

The enabled lines have been checked to match the sections names, and only the `sshd` and `sshd-ddos` do not match the  *enabled* lines in to match the other templates.

This incidentally fixes the root problem addressed in #75, but if this PR is accepted, I can follow-up in that other PR to include the acceptance tests.

#### This Pull Request (PR) fixes the following issues
n/a