### PR TITLE
Bugfix for broken epp templates

### DIFF
--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -29,7 +29,15 @@ define fail2ban::jail (
   file { "custom_filter_${name}":
     ensure  => file,
     path    => "${config_dir_filter_path}/${name}.conf",
-    content => epp('fail2ban/common/custom_filter.conf.epp'),
+    content => epp('fail2ban/common/custom_filter.conf.epp',
+      {
+        findtime                 => $findtime,
+        filter_includes          => $filter_includes,
+        filter_additional_config => $filter_additional_config,
+        filter_failregex         => $filter_failregex,
+        filter_ignoreregex       => $filter_ignoreregex,
+      }
+    ),
     owner   => $config_file_owner,
     group   => $config_file_group,
     mode    => $config_file_mode,
@@ -41,7 +49,21 @@ define fail2ban::jail (
   file { "custom_jail_${name}":
     ensure  => file,
     path    => "${::fail2ban::params::config_dir_path}/jail.d/${name}.conf",
-    content => epp('fail2ban/common/custom_jail.conf.epp'),
+    content => epp('fail2ban/common/custom_jail.conf.epp',
+      {
+        name     => $name,
+        enabled  => $enabled,
+        action   => $action,
+        filter   => $filter,
+        logpath  => $logpath,
+        maxretry => $maxretry,
+        findtime => $findtime,
+        bantime  => $bantime,
+        port     => $port,
+        backend  => $backend,
+        ignoreip => $ignoreip,
+      }
+    ),
     owner   => $config_file_owner,
     group   => $config_file_group,
     mode    => $config_file_mode,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -297,7 +297,7 @@ describe 'fail2ban', type: :class do
 
       describe 'fail2ban::jail' do
         it do
-          is_expected.to compile
+          is_expected.to compile.with_all_deps
         end
       end
     end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -294,6 +294,12 @@ describe 'fail2ban', type: :class do
           end
         end
       end
+
+      describe 'fail2ban::jail' do
+        it do
+          is_expected.to compile
+        end
+      end
     end
   end
 end

--- a/spec/defines/fail2ban_jail_spec.rb
+++ b/spec/defines/fail2ban_jail_spec.rb
@@ -3,43 +3,39 @@ require 'spec_helper'
 describe 'fail2ban::jail' do
   let(:title) { 'spec_test_jail' }
   let(:pre_condition) { 'include fail2ban' }
-  let(:facts) do
-    {
-      'os' => {
-        'family'  => 'RedHat',
-        'release' => {
-          'major' => '7',
-          'minor' => '1',
-          'full'  => '7.1.1503'
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      let(:params) do
+        {
+          'logpath'          => '/var/log/syslog',
+          'filter_failregex' => 'Login failed for user .* from <HOST>'
         }
-      }
-    }
-  end
+      end
 
-  let(:params) do
-    {
-      'logpath'          => '/var/log/syslog',
-      'filter_failregex' => 'Login failed for user .* from <HOST>'
-    }
-  end
+      it do
+        is_expected.to compile.with_all_deps
+      end
 
-  it do
-    is_expected.to compile
-  end
+      it do
+        is_expected.to contain_file('custom_jail_spec_test_jail').with(
+          'ensure'  => 'file',
+          'notify'  => 'Service[fail2ban]',
+          'content' => %r{\[spec_test_jail\]}
+        )
+      end
 
-  it do
-    is_expected.to contain_file('custom_jail_spec_test_jail').with(
-      'ensure'  => 'file',
-      'notify'  => 'Service[fail2ban]',
-      'content' => %r{\[spec_test_jail\]}
-    )
-  end
-
-  it do
-    is_expected.to contain_file('custom_filter_spec_test_jail').with(
-      'ensure'  => 'file',
-      'notify'  => 'Service[fail2ban]',
-      'content' => %r{failregex = Login failed for user .* from <HOST>}
-    )
+      it do
+        is_expected.to contain_file('custom_filter_spec_test_jail').with(
+          'ensure'  => 'file',
+          'notify'  => 'Service[fail2ban]',
+          'content' => %r{failregex = Login failed for user .* from <HOST>}
+        )
+      end
+    end
   end
 end

--- a/spec/defines/fail2ban_jail_spec.rb
+++ b/spec/defines/fail2ban_jail_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'fail2ban::jail' do
+  let(:title) { 'spec_test_jail' }
+  let(:pre_condition) { 'include fail2ban' }
+  let(:facts) do
+    {
+      'os' => {
+        'family'  => 'RedHat',
+        'release' => {
+          'major' => '7',
+          'minor' => '1',
+          'full'  => '7.1.1503'
+        }
+      }
+    }
+  end
+
+  let(:params) do
+    {
+      'logpath'          => '/var/log/syslog',
+      'filter_failregex' => 'Login failed for user .* from <HOST>'
+    }
+  end
+
+  it do
+    is_expected.to compile
+  end
+
+  it do
+    is_expected.to contain_file('custom_jail_spec_test_jail').with(
+      'ensure'  => 'file',
+      'notify'  => 'Service[fail2ban]',
+      'content' => %r{\[spec_test_jail\]}
+    )
+  end
+
+  it do
+    is_expected.to contain_file('custom_filter_spec_test_jail').with(
+      'ensure'  => 'file',
+      'notify'  => 'Service[fail2ban]',
+      'content' => %r{failregex = Login failed for user .* from <HOST>}
+    )
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
epp templates for custom jails and filters are broken due to epp not being able to directly reach into the calling class's variable scope. Workaround implemented by passing the required variables into the epp function call in the defined type code.

#### This Pull Request (PR) fixes the following issues
Fixes #74 
Fixes #27 