### PR TITLE
Replace UTF8 dash and quotes in templates

### DIFF
--- a/templates/Tikanga/etc/fail2ban/jail.conf.epp
+++ b/templates/Tikanga/etc/fail2ban/jail.conf.epp
@@ -286,7 +286,7 @@ logpath = /var/www/*/logs/access_log
 # A simple PHP-fastcgi jail which works with lighttpd.
 # If you run a lighttpd server, then you probably will
 # find these kinds of messages in your error_log:
-#   ALERT – tried to register forbidden variable ‘GLOBALS’
+#   ALERT - tried to register forbidden variable 'GLOBALS'
 #   through GET variables (attacker '1.2.3.4', file '/var/www/default/htdocs/index.php')
 
 [lighttpd-fastcgi]

--- a/templates/jessie/etc/fail2ban/jail.conf.epp
+++ b/templates/jessie/etc/fail2ban/jail.conf.epp
@@ -286,7 +286,7 @@ logpath = /var/www/*/logs/access_log
 # A simple PHP-fastcgi jail which works with lighttpd.
 # If you run a lighttpd server, then you probably will
 # find these kinds of messages in your error_log:
-#   ALERT – tried to register forbidden variable ‘GLOBALS’
+#   ALERT - tried to register forbidden variable 'GLOBALS'
 #   through GET variables (attacker '1.2.3.4', file '/var/www/default/htdocs/index.php')
 
 [lighttpd-fastcgi]

--- a/templates/trusty/etc/fail2ban/jail.conf.epp
+++ b/templates/trusty/etc/fail2ban/jail.conf.epp
@@ -262,7 +262,7 @@ logpath = /var/www/*/logs/access_log
 # A simple PHP-fastcgi jail which works with lighttpd.
 # If you run a lighttpd server, then you probably will
 # find these kinds of messages in your error_log:
-#   ALERT – tried to register forbidden variable ‘GLOBALS’
+#   ALERT - tried to register forbidden variable 'GLOBALS'
 #   through GET variables (attacker '1.2.3.4', file '/var/www/default/htdocs/index.php')
 
 [lighttpd-fastcgi]


### PR DESCRIPTION
Replaces uses of the unicode characters `U+2013` `U+2018` and `U+2019` (`EN DASH`, `LEFT SINGLE QUOTATION MARK` and `RIGHT SINGLE QUOTATION MARK` respectively) with their ASCII equivalents in various templates.

Fixes #105 
