### PR TITLE
depend on extlib 3 & prefix extlib function call

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,7 @@ class fail2ban (
   Hash[String, Hash] $custom_jails = {},
   String[1] $banaction = 'iptables-multiport',
 ) inherits ::fail2ban::params {
-  $config_file_content = default_content($config_file_string, $config_file_template)
+  $config_file_content = extlib::default_content($config_file_string, $config_file_template)
 
   if $config_file_hash {
     create_resources('fail2ban::define', $config_file_hash)

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppet/extlib",
-      "version_requirement": ">= 2.3.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Without this, we get:
  Warning: This method is deprecated, please use extlib::default_content instead. at ["/etc/puppetlabs/code/modules/fail2ban/manifests/init.pp", 44]:
   (location: /etc/puppetlabs/code/environments/production/modules/stdlib/lib/puppet/functions/deprecation.rb:28:in `deprecation')

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
