### PR TITLE
Fix non namespaced extlib function

### DIFF
--- a/manifests/define.pp
+++ b/manifests/define.pp
@@ -14,7 +14,7 @@ define fail2ban::define (
 
   Hash $config_file_options_hash = $fail2ban::config_file_options_hash,
 ) {
-  $config_file_content = default_content($config_file_string, $config_file_template)
+  $config_file_content = extlib::default_content($config_file_string, $config_file_template)
 
   file { "define_${name}":
     ensure  => $fail2ban::config_file_ensure,


### PR DESCRIPTION
This commit fixes the `default_content`, from extlib module, function usage: this non-namespaced function is deprecated since extlib v3 and have been removed in v5.

Please note that releasing a new version could be welcome by users ;-)

BTW, thanks for your work.