### PR TITLE
Add support for multiple data types

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,7 @@ class fail2ban (
   Boolean $service_enable = true,
 
   String[1] $action = 'action_mb',
-  Integer[0] $bantime = 432000,
+  Variant[Integer[0], String[1]] $bantime = 432000,
   String[1] $email = "fail2ban@${facts['networking']['domain']}",
   String[1] $sender = "fail2ban@${facts['networking']['fqdn']}",
   String[1] $iptables_chain = 'INPUT',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -236,6 +236,21 @@ describe 'fail2ban', type: :class do
           end
         end
 
+        context 'when bantime provided as string' do
+          let(:params) do
+            {
+              config_file_template: config_file_template,
+              bantime: '12h'
+            }
+          end
+
+          it do
+            is_expected.to contain_file('fail2ban.conf').with_content(
+              %r{^bantime  = 12h$}
+            )
+          end
+        end
+
         context 'when custom banaction is provided' do
           let(:params) do
             {


### PR DESCRIPTION
Upstream uses a different time format since 2014:
* https://github.com/fail2ban/fail2ban/blob/master/config/jail.conf#L101

Fixes #139 