### PR TITLE
Fix apache-badbots on RedHat

### DIFF
--- a/templates/RedHat/6/etc/fail2ban/jail.conf.epp
+++ b/templates/RedHat/6/etc/fail2ban/jail.conf.epp
@@ -259,7 +259,7 @@ logpath  = %(apache_error_log)s
 [apache-badbots]
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
-# enabled = <%= "apache-badbots" in $fail2ban::jails %>
+enabled = <%= "apache-badbots" in $fail2ban::jails %>
 port     = http,https
 logpath  = %(apache_access_log)s
 bantime  = 172800

--- a/templates/RedHat/7/etc/fail2ban/jail.conf.epp
+++ b/templates/RedHat/7/etc/fail2ban/jail.conf.epp
@@ -259,7 +259,7 @@ logpath  = %(apache_error_log)s
 [apache-badbots]
 # Ban hosts which agent identifies spammer robots crawling the web
 # for email addresses. The mail outputs are buffered.
-# enabled = <%= "apache-badbots" in $fail2ban::jails %>
+enabled = <%= "apache-badbots" in $fail2ban::jails %>
 port     = http,https
 logpath  = %(apache_access_log)s
 bantime  = 172800


### PR DESCRIPTION
These lines were probably commented out by mistake in refactoring (d9d2d03d396fb1d24ff7602d253c9748c99b9cdc).

Btw. there are no acceptance tests for RedHat, it might be safer to use Centos templates (if there are no substantial differences).