### PR TITLE
Use actual Debian 11 configuration

### DIFF
--- a/templates/Debian/11/etc/fail2ban/jail.conf.epp
+++ b/templates/Debian/11/etc/fail2ban/jail.conf.epp
@@ -46,9 +46,47 @@ before = paths-debian.conf
 # MISCELLANEOUS OPTIONS
 #
 
-# "ignorself" specifies whether the local resp. own IP addresses should be ignored
+# "bantime.increment" allows to use database for searching of previously banned ip's to increase a
+# default ban time using special formula, default it is banTime * 1, 2, 4, 8, 16, 32...
+#bantime.increment = true
+
+# "bantime.rndtime" is the max number of seconds using for mixing with random time
+# to prevent "clever" botnets calculate exact time IP can be unbanned again:
+#bantime.rndtime =
+
+# "bantime.maxtime" is the max number of seconds using the ban time can reach (doesn't grow further)
+#bantime.maxtime =
+
+# "bantime.factor" is a coefficient to calculate exponent growing of the formula or common multiplier,
+# default value of factor is 1 and with default value of formula, the ban time
+# grows by 1, 2, 4, 8, 16 ...
+#bantime.factor = 1
+
+# "bantime.formula" used by default to calculate next value of ban time, default value below,
+# the same ban time growing will be reached by multipliers 1, 2, 4, 8, 16, 32...
+#bantime.formula = ban.Time * (1<<(ban.Count if ban.Count<20 else 20)) * banFactor
+#
+# more aggressive example of formula has the same values only for factor "2.0 / 2.885385" :
+#bantime.formula = ban.Time * math.exp(float(ban.Count+1)*banFactor)/math.exp(1*banFactor)
+
+# "bantime.multipliers" used to calculate next value of ban time instead of formula, coresponding
+# previously ban count and given "bantime.factor" (for multipliers default is 1);
+# following example grows ban time by 1, 2, 4, 8, 16 ... and if last ban count greater as multipliers count,
+# always used last multiplier (64 in example), for factor '1' and original ban time 600 - 10.6 hours
+#bantime.multipliers = 1 2 4 8 16 32 64
+# following example can be used for small initial ban time (bantime=60) - it grows more aggressive at begin,
+# for bantime=60 the multipliers are minutes and equal: 1 min, 5 min, 30 min, 1 hour, 5 hour, 12 hour, 1 day, 2 day
+#bantime.multipliers = 1 5 30 60 300 720 1440 2880
+
+# "bantime.overalljails" (if true) specifies the search of IP in the database will be executed
+# cross over all jails, if false (dafault), only current jail of the ban IP will be searched
+#bantime.overalljails = false
+
+# --------------------
+
+# "ignoreself" specifies whether the local resp. own IP addresses should be ignored
 # (default is true). Fail2ban will not ban a host which matches such addresses.
-#ignorself = true
+#ignoreself = true
 
 # "ignoreip" can be a list of IP addresses, CIDR masks or DNS hosts. Fail2ban
 # will not ban a host which matches an address in this list. Several addresses
@@ -70,6 +108,9 @@ findtime  = 10m
 
 # "maxretry" is the number of failures before a host get banned.
 maxretry = <%= $fail2ban::maxretry %>
+
+# "maxmatches" is the number of matches stored in ticket (resolvable via tag <matches> in actions).
+maxmatches = %(maxretry)s
 
 # "backend" specifies the backend used to get files modification.
 # Available options are "pyinotify", "gamin", "polling", "systemd" and "auto".
@@ -177,35 +218,35 @@ action_mb = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port
             %(mta)s-buffered[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
 
 # ban & send an e-mail with whois report to the destemail.
-action_mw = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
+action_mw = %(action_)s
             %(mta)s-whois[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", protocol="%(protocol)s", chain="%(chain)s"]
 
 # ban & send an e-mail with whois report and relevant log lines
 # to the destemail.
-action_mwl = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
-             %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+action_mwl = %(action_)s
+             %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath="%(logpath)s", chain="%(chain)s"]
 
 # See the IMPORTANT note in action.d/xarf-login-attack for when to use this action
 #
 # ban & send a xarf e-mail to abuse contact of IP address and include relevant log lines
 # to the destemail.
-action_xarf = %(banaction)s[name=%(__name__)s, bantime="%(bantime)s", port="%(port)s", protocol="%(protocol)s", chain="%(chain)s"]
-             xarf-login-attack[service=%(__name__)s, sender="%(sender)s", logpath=%(logpath)s, port="%(port)s"]
+action_xarf = %(action_)s
+             xarf-login-attack[service=%(__name__)s, sender="%(sender)s", logpath="%(logpath)s", port="%(port)s"]
 
 # ban IP on CloudFlare & send an e-mail with whois report and relevant log lines
 # to the destemail.
 action_cf_mwl = cloudflare[cfuser="%(cfemail)s", cftoken="%(cfapikey)s"]
-                %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath=%(logpath)s, chain="%(chain)s"]
+                %(mta)s-whois-lines[name=%(__name__)s, sender="%(sender)s", dest="%(destemail)s", logpath="%(logpath)s", chain="%(chain)s"]
 
 # Report block via blocklist.de fail2ban reporting service API
-# 
+#
 # See the IMPORTANT note in action.d/blocklist_de.conf for when to use this action.
 # Specify expected parameters in file action.d/blocklist_de.local or if the interpolation
 # `action_blocklist_de` used for the action, set value of `blocklist_de_apikey`
-# in your `jail.local` globally (section [DEFAULT]) or per specific jail section (resp. in 
+# in your `jail.local` globally (section [DEFAULT]) or per specific jail section (resp. in
 # corresponding jail.d/my-jail.local file).
 #
-action_blocklist_de  = blocklist_de[email="%(sender)s", service=%(filter)s, apikey="%(blocklist_de_apikey)s", agent="%(fail2ban_agent)s"]
+action_blocklist_de  = blocklist_de[email="%(sender)s", service="%(__name__)s", apikey="%(blocklist_de_apikey)s", agent="%(fail2ban_agent)s"]
 
 # Report ban via badips.com, and use as blacklist
 #
@@ -285,7 +326,7 @@ logpath  = %(apache_error_log)s
 enabled  = <%= "apache-badbots" in $fail2ban::jails %>
 port     = http,https
 logpath  = %(apache_access_log)s
-bantime  = 172800
+bantime  = 48h
 maxretry = 1
 
 
@@ -349,7 +390,7 @@ maxretry = 1
 
 enabled  = <%= "openhab-auth" in $fail2ban::jails %>
 filter = openhab
-action = iptables-allports[name=NoAuthFailures]
+banaction = %(banaction_allports)s
 logpath = /opt/openhab/logs/request.log
 
 
@@ -359,7 +400,7 @@ enabled  = <%= "nginx-http-auth" in $fail2ban::jails %>
 port    = http,https
 logpath = %(nginx_error_log)s
 
-# To use 'nginx-limit-req' jail you should have `ngx_http_limit_req_module` 
+# To use 'nginx-limit-req' jail you should have `ngx_http_limit_req_module`
 # and define `limit_req` and `limit_req_zone` as described in nginx documentation
 # http://nginx.org/en/docs/http/ngx_http_limit_req_module.html
 # or for example see in 'config/filter.d/nginx-limit-req.conf'
@@ -471,12 +512,14 @@ backend  = %(syslog_backend)s
 enabled = <%= "guacamole" in $fail2ban::jails %>
 port     = http,https
 logpath  = /var/log/tomcat*/catalina.out
+#logpath  = /var/log/guacamole.log
 
 [monit]
 #Ban clients brute-forcing the monit gui login
 enabled = <%= "monit" in $fail2ban::jails %>
 port = 2812
 logpath  = /var/log/monit
+           /var/log/monit.log
 
 
 [webmin-auth]
@@ -585,15 +628,16 @@ backend  = %(syslog_backend)s
 [postfix]
 # To use another modes set filter parameter "mode" in jail.local:
 mode    = more
-enabled  = <%= "postfix" in $fail2ban::jails %>
-port     = smtp,465,submission
-logpath  = %(postfix_log)s
-backend  = %(postfix_backend)s
+enabled = <%= "postfix" in $fail2ban::jails %>
+port    = smtp,465,submission
+logpath = %(postfix_log)s
+backend = %(postfix_backend)s
 
 
 [postfix-rbl]
 
 enabled  = <%= "postfix-rbl" in $fail2ban::jails %>
+filter   = postfix[mode=rbl]
 port     = smtp,465,submission
 logpath  = %(postfix_log)s
 backend  = %(postfix_backend)s
@@ -710,7 +754,7 @@ backend = %(syslog_backend)s
 [squirrelmail]
 
 enabled  = <%= "squirrelmail" in $fail2ban::jails %>
-port = smtp,465,submission,imap2,imap,imaps,pop3,pop3s,http,https,socks
+port = smtp,465,submission,imap,imap2,imaps,pop3,pop3s,http,https,socks
 logpath = /var/lib/squirrelmail/prefs/squirrelmail_access_log
 
 
@@ -767,8 +811,8 @@ logpath  = /var/log/named/security.log
 
 enabled  = <%= "nsd" in $fail2ban::jails %>
 port     = 53
-action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
 logpath = /var/log/nsd.log
 
 
@@ -780,9 +824,8 @@ logpath = /var/log/nsd.log
 
 enabled  = <%= "asterisk" in $fail2ban::jails %>
 port     = 5060,5061
-action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
-           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
 logpath  = /var/log/asterisk/messages
 maxretry = 10
 
@@ -791,16 +834,23 @@ maxretry = 10
 
 enabled  = <%= "freeswitch" in $fail2ban::jails %>
 port     = 5060,5061
-action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
-           %(mta)s-whois[name=%(__name__)s, dest="%(destemail)s"]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
 logpath  = /var/log/freeswitch.log
 maxretry = 10
 
 
+# enable adminlog; it will log to a file inside znc's directory by default.
+[znc-adminlog]
+
+enabled  = <%= "znc-adminlog" in $fail2ban::jails %>
+port     = 6667
+logpath  = /var/lib/znc/moddata/adminlog/znc.log
+
+
 # To log wrong MySQL access attempts add to /etc/my.cnf in [mysqld] or
 # equivalent section:
-# log-warning = 2
+# log-warnings = 2
 #
 # for syslog (daemon facility)
 # [mysqld_safe]
@@ -880,11 +930,36 @@ logpath = /var/log/ejabberd/ejabberd.log
 
 enabled  = <%= "counter-strike" in $fail2ban::jails %>
 logpath = /opt/cstrike/logs/L[0-9]*.log
-# Firewall: http://www.cstrike-planet.com/faq/6
 tcpport = 27030,27031,27032,27033,27034,27035,27036,27037,27038,27039
 udpport = 1200,27000,27001,27002,27003,27004,27005,27006,27007,27008,27009,27010,27011,27012,27013,27014,27015
-action  = %(banaction)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp", chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp", chain="%(chain)s", actname=%(banaction)s-udp]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, port="%(tcpport)s", protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, port="%(udpport)s", protocol="udp"]
+
+[softethervpn]
+enabled  = <%= "softethervpn" in $fail2ban::jails %>
+port     = 500,4500
+protocol = udp
+logpath  = /usr/local/vpnserver/security_log/*/sec.log
+
+[gitlab]
+enabled  = <%= "gitlab" in $fail2ban::jails %>
+port    = http,https
+logpath = /var/log/gitlab/gitlab-rails/application.log
+
+[grafana]
+enabled  = <%= "grafana" in $fail2ban::jails %>
+port    = http,https
+logpath = /var/log/grafana/grafana.log
+
+[bitwarden]
+enabled  = <%= "bitwarden" in $fail2ban::jails %>
+port    = http,https
+logpath = /home/*/bwdata/logs/identity/Identity/log.txt
+
+[centreon]
+enabled  = <%= "centreon" in $fail2ban::jails %>
+port    = http,https
+logpath = /var/log/centreon/login.log
 
 # consider low maxretry and a long bantime
 # nobody except your own Nagios server should ever probe nrpe
@@ -925,7 +1000,8 @@ filter       = apache-pass[knocking_url="%(knocking_url)s"]
 logpath      = %(apache_access_log)s
 blocktype    = RETURN
 returntype   = DROP
-action       = %(action_)s[blocktype=%(blocktype)s, returntype=%(returntype)s]
+action       = %(action_)s[blocktype=%(blocktype)s, returntype=%(returntype)s,
+                        actionstart_on_demand=false, actionrepair_on_unban=true]
 bantime      = 1h
 maxretry     = 1
 findtime     = 1
@@ -935,8 +1011,8 @@ findtime     = 1
 # AKA mumble-server
 enabled  = <%= "murmur" in $fail2ban::jails %>
 port     = 64738
-action   = %(banaction)s[name=%(__name__)s-tcp, port="%(port)s", protocol=tcp, chain="%(chain)s", actname=%(banaction)s-tcp]
-           %(banaction)s[name=%(__name__)s-udp, port="%(port)s", protocol=udp, chain="%(chain)s", actname=%(banaction)s-udp]
+action_  = %(default/action_)s[name=%(__name__)s-tcp, protocol="tcp"]
+           %(default/action_)s[name=%(__name__)s-udp, protocol="udp"]
 logpath  = /var/log/mumble-server/mumble-server.log
 
 
@@ -960,18 +1036,27 @@ port    = ldap,ldaps
 logpath = /var/log/slapd.log
 
 [domino-smtp]
+enabled  = <%= "domino-smtp" in $fail2ban::jails %>
 port    = smtp,ssmtp
 logpath = /home/domino01/data/IBM_TECHNICAL_SUPPORT/console.log
 
 [phpmyadmin-syslog]
+enabled  = <%= "phpmyadmin-syslog" in $fail2ban::jails %>
 port    = http,https
 logpath = %(syslog_authpriv)s
 backend = %(syslog_backend)s
 
 
 [zoneminder]
+enabled  = <%= "zoneminder" in $fail2ban::jails %>
 # Zoneminder HTTP/HTTPS web interface auth
 # Logs auth failures to apache2 error log
 port    = http,https
 logpath = %(apache_error_log)s
 
+[traefik-auth]
+enabled  = <%= "traefik-auth" in $fail2ban::jails %>
+# to use 'traefik-auth' filter you have to configure your Traefik instance,
+# see `filter.d/traefik-auth.conf` for details and service example.
+port    = http,https
+logpath = /var/log/traefik/access.log


### PR DESCRIPTION
This was in fact an exact copy on the Debian 10 config.  Use the Debian
11 configuration as a base and adjust it to match the (not recommanded)
way this module configure fail2ban.
