### PR TITLE
Allow puppetlabs-stdlib 9.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 9.0.0"
+      "version_requirement": ">= 4.25.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
* Allow puppetlabs-stdlib 9.x
