### PR TITLE
Add tasks to ban/unban IP addresses in jails

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,6 +16,12 @@
 * [`fail2ban::define`](#fail2ban--define): == Define: fail2ban::define
 * [`fail2ban::jail`](#fail2ban--jail): == Define: fail2ban::jail
 
+### Tasks
+
+* [`banip`](#banip): Ban IPs in a jail
+* [`unban`](#unban): Unban IP in all jails and database
+* [`unbanip`](#unbanip): Unban IP in a jail
+
 ## Classes
 
 ### <a name="fail2ban"></a>`fail2ban`
@@ -704,4 +710,60 @@ Data type: `Optional[String]`
 
 
 Default value: `$fail2ban::config_file_require`
+
+## Tasks
+
+### <a name="banip"></a>`banip`
+
+Ban IPs in a jail
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `jail`
+
+Data type: `String[1]`
+
+The jail to operate on
+
+##### `ips`
+
+Data type: `Array[Stdlib::IP::Address]`
+
+IP addresses to ban
+
+### <a name="unban"></a>`unban`
+
+Unban IP in all jails and database
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `ips`
+
+Data type: `Array[Stdlib::IP::Address]`
+
+IP addresses to unban
+
+### <a name="unbanip"></a>`unbanip`
+
+Unban IP in a jail
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `jail`
+
+Data type: `String[1]`
+
+The jail to operate on
+
+##### `ips`
+
+Data type: `Array[Stdlib::IP::Address]`
+
+IP addresses to unban
 

--- a/tasks/banip.json
+++ b/tasks/banip.json
@@ -1,0 +1,17 @@
+{
+  "description": "Ban IPs in a jail",
+  "input_method": "stdin",
+  "files": [
+    "ruby_task_helper/files/task_helper.rb"
+  ],
+  "parameters": {
+    "jail": {
+      "description": "The jail to operate on",
+      "type": "String[1]"
+    },
+    "ips": {
+      "description": "IP addresses to ban",
+      "type": "Array[Stdlib::IP::Address]"
+    }
+  }
+}

--- a/tasks/banip.rb
+++ b/tasks/banip.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../ruby_task_helper/files/task_helper'
+
+class Fail2banBanipTask < TaskHelper
+  def task(jail:, ips:, **_kwargs)
+    command = ['fail2ban-client', 'set', jail, 'banip'] + ips
+
+    pid = Process.spawn(*command)
+    Process.wait(pid)
+
+    nil
+  end
+end
+
+Fail2banBanipTask.run if $PROGRAM_NAME == __FILE__

--- a/tasks/unban.json
+++ b/tasks/unban.json
@@ -1,0 +1,13 @@
+{
+  "description": "Unban IP in all jails and database",
+  "input_method": "stdin",
+  "files": [
+    "ruby_task_helper/files/task_helper.rb"
+  ],
+  "parameters": {
+    "ips": {
+      "description": "IP addresses to unban",
+      "type": "Array[Stdlib::IP::Address]"
+    }
+  }
+}

--- a/tasks/unban.rb
+++ b/tasks/unban.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../ruby_task_helper/files/task_helper'
+
+class Fail2banUnbanTask < TaskHelper
+  def task(ips:, **_kwargs)
+    command = %w[fail2ban-client unban] + ips
+
+    pid = Process.spawn(*command)
+    Process.wait(pid)
+
+    nil
+  end
+end
+
+Fail2banUnbanTask.run if $PROGRAM_NAME == __FILE__

--- a/tasks/unbanip.json
+++ b/tasks/unbanip.json
@@ -1,0 +1,17 @@
+{
+  "description": "Unban IP in a jail",
+  "input_method": "stdin",
+  "files": [
+    "ruby_task_helper/files/task_helper.rb"
+  ],
+  "parameters": {
+    "jail": {
+      "description": "The jail to operate on",
+      "type": "String[1]"
+    },
+    "ips": {
+      "description": "IP addresses to unban",
+      "type": "Array[Stdlib::IP::Address]"
+    }
+  }
+}

--- a/tasks/unbanip.rb
+++ b/tasks/unbanip.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../../ruby_task_helper/files/task_helper'
+
+class Fail2banUnbanipTask < TaskHelper
+  def task(jail:, ips:, **_kwargs)
+    command = ['fail2ban-client', 'set', jail, 'unbanip'] + ips
+
+    pid = Process.spawn(*command)
+    Process.wait(pid)
+
+    nil
+  end
+end
+
+Fail2banUnbanipTask.run if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
The fail2ban-client tool allows a large panel of acions.  Start with the
most simple and frequently used ones to ban/unban IP addresses in
fail2ban jails.

Next time I lock me out of a system through SSH, I will be happy to rely
on these tasks with choria to unlock me.
