### PR TITLE
release 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
+## [v5.0.1](https://github.com/voxpupuli/puppet-fail2ban/tree/v5.0.1) (2024-09-17)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-fail2ban/compare/v5.0.0...v5.0.1)
+
+**Fixed bugs:**
+
+- modulesync 9.3.0 - fix release process [\#220](https://github.com/voxpupuli/puppet-fail2ban/pull/220) ([bastelfreak](https://github.com/bastelfreak))
+
 ## [v5.0.0](https://github.com/voxpupuli/puppet-fail2ban/tree/v5.0.0) (2024-09-16)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-fail2ban/compare/v4.2.0...v5.0.0)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-fail2ban",
-  "version": "5.0.1-rc0",
+  "version": "5.0.1",
   "author": "Vox Pupuli",
   "summary": "This module installs, configures and manages the Fail2ban service.",
   "license": "Apache-2.0",


### PR DESCRIPTION
The `5.0.0` release could not be pushed to forge because of problems with the release workflow, which was fixed by #220.  Per discussion on slack, a new release is preferable to updating the `5.0.0` tag and rewriting history to remove the `5.0.1-rc0` commit.