### PR TITLE
jail logpath can handle several files

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -23,6 +23,7 @@
 
 ### Data types
 
+* [`Fail2ban::Logpath`](#Fail2ban--Logpath): Describes logpath format allowed
 * [`Fail2ban::Time`](#Fail2ban--Time): Describes time format allowed for bantime and findtime The time entries in fail2ban configuration (like findtime or bantime) can be provided 
 
 ### Tasks
@@ -496,6 +497,7 @@ Handles the jails.
 
 The following parameters are available in the `fail2ban::jail` defined type:
 
+* [`logpath`](#-fail2ban--jail--logpath)
 * [`filter_includes`](#-fail2ban--jail--filter_includes)
 * [`filter_failregex`](#-fail2ban--jail--filter_failregex)
 * [`filter_ignoreregex`](#-fail2ban--jail--filter_ignoreregex)
@@ -505,7 +507,6 @@ The following parameters are available in the `fail2ban::jail` defined type:
 * [`enabled`](#-fail2ban--jail--enabled)
 * [`action`](#-fail2ban--jail--action)
 * [`filter`](#-fail2ban--jail--filter)
-* [`logpath`](#-fail2ban--jail--logpath)
 * [`maxretry`](#-fail2ban--jail--maxretry)
 * [`findtime`](#-fail2ban--jail--findtime)
 * [`bantime`](#-fail2ban--jail--bantime)
@@ -520,6 +521,14 @@ The following parameters are available in the `fail2ban::jail` defined type:
 * [`config_file_source`](#-fail2ban--jail--config_file_source)
 * [`config_file_notify`](#-fail2ban--jail--config_file_notify)
 * [`config_file_require`](#-fail2ban--jail--config_file_require)
+
+##### <a name="-fail2ban--jail--logpath"></a>`logpath`
+
+Data type: `Optional[Fail2ban::Logpath]`
+
+Filename(s) of the log files to be monitored
+
+Default value: `undef`
 
 ##### <a name="-fail2ban--jail--filter_includes"></a>`filter_includes`
 
@@ -592,14 +601,6 @@ Data type: `String`
 
 
 Default value: `$title`
-
-##### <a name="-fail2ban--jail--logpath"></a>`logpath`
-
-Data type: `Optional[String[1]]`
-
-
-
-Default value: `undef`
 
 ##### <a name="-fail2ban--jail--maxretry"></a>`maxretry`
 
@@ -714,6 +715,12 @@ Data type: `Optional[String]`
 Default value: `$fail2ban::config_file_require`
 
 ## Data types
+
+### <a name="Fail2ban--Logpath"></a>`Fail2ban::Logpath`
+
+Describes logpath format allowed
+
+Alias of `Variant[String[1], Array[String[1]]]`
 
 ### <a name="Fail2ban--Time"></a>`Fail2ban::Time`
 

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -1,5 +1,7 @@
 # @summary Handles the jails.
 #
+# @param logpath Filename(s) of the log files to be monitored
+#
 define fail2ban::jail (
   Optional[String] $filter_includes = undef,
   Optional[String] $filter_failregex = undef,
@@ -10,7 +12,7 @@ define fail2ban::jail (
   Boolean $enabled = true,
   Optional[String] $action = undef,
   String $filter = $title,
-  Optional[String[1]] $logpath = undef,
+  Optional[Fail2ban::Logpath] $logpath = undef,
   Integer $maxretry = $fail2ban::maxretry,
   Optional[Fail2ban::Time] $findtime = undef,
   Fail2ban::Time $bantime = $fail2ban::bantime,

--- a/spec/type_aliases/logpath_spec.rb
+++ b/spec/type_aliases/logpath_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Fail2ban::Logpath' do
+  [
+    '/var/log/file.log',
+    '/var/log/file.log[1-9]',
+    ['/var/log/file.log', '/var/log/file.log.1'],
+  ].each do |allowed_value|
+    it { is_expected.to allow_value(allowed_value) }
+  end
+end

--- a/templates/common/custom_jail.conf.epp
+++ b/templates/common/custom_jail.conf.epp
@@ -9,7 +9,13 @@ enabled  = <%= $enabled %>
 action   = <%= $action %>
 <% } -%>
 filter   = <%= $filter %>
+<% if $logpath  =~ Array[String[1]] { -%>
+logpath  = <%- $logpath.each |$l| { -%>
+ <%= $l %>
+<%- } -%>
+<% } else { -%>
 logpath  = <%= $logpath %>
+<%- } -%>
 maxretry = <%= $maxretry %>
 <% if $findtime { -%>
 findtime     = <%= $findtime %>

--- a/types/logpath.pp
+++ b/types/logpath.pp
@@ -1,0 +1,5 @@
+# Describes logpath format allowed
+type Fail2ban::Logpath = Variant[
+  String[1],
+  Array[String[1]],
+]


### PR DESCRIPTION
Before this PR a jail was able to monitor only one log file.
But with fail2ban, a jail can monitor several files.
This PR permits to monitor several log files with one jail.
  
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
